### PR TITLE
BAN-102 BAN-103: Add watcher deployment pipeline

### DIFF
--- a/.github/actions/deploy-helm/action.yml
+++ b/.github/actions/deploy-helm/action.yml
@@ -1,0 +1,130 @@
+name: Deploy with Helm
+description: Deploy watcher worker to Kubernetes using Helm charts
+
+inputs:
+  app-name:
+    description: Application name
+    required: true
+  image-name:
+    description: Docker image name with tag
+    required: true
+  namespace:
+    description: Kubernetes namespace
+    required: true
+    default: elderbot
+  replica-count:
+    description: Number of replicas
+    required: false
+    default: "1"
+  deployment-vars:
+    description: Path to deployment variables YAML file
+    required: false
+    default: /tmp/deployment_vars.yml
+  kubeconfig:
+    description: Base64 encoded kubeconfig
+    required: true
+  dockercfg:
+    description: Base64 encoded Docker config JSON
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Kubernetes access
+      shell: bash
+      env:
+        KUBECONFIG_INPUT: ${{ inputs.kubeconfig }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${KUBECONFIG_INPUT}" ]]; then
+          echo "KUBECONFIG input is empty. Check the KUBECONFIG secret." >&2
+          exit 1
+        fi
+
+        # Support both base64-encoded kubeconfig and raw YAML kubeconfig.
+        if ! printf "%s" "${KUBECONFIG_INPUT}" | base64 -d > kubeconfig 2>/dev/null; then
+          printf "%s" "${KUBECONFIG_INPUT}" > kubeconfig
+        fi
+
+        if [[ ! -s kubeconfig ]]; then
+          echo "Generated kubeconfig file is empty." >&2
+          exit 1
+        fi
+
+        if ! grep -q '^apiVersion:' kubeconfig; then
+          echo "Generated kubeconfig does not look valid (missing apiVersion)." >&2
+          exit 1
+        fi
+
+        if grep -Eq 'server:[[:space:]]*https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)(:[0-9]+)?([[:space:]]|$)' kubeconfig; then
+          echo "Kubeconfig points to localhost. Check KUBECONFIG cluster server." >&2
+          exit 1
+        fi
+
+        chmod 400 kubeconfig
+
+    - name: Install Helm
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    - name: Validate Helm chart files
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        chart_dir="kubernetes/worker-service"
+        required_files=(
+          "$chart_dir/Chart.yaml"
+          "$chart_dir/values.yaml"
+          "$chart_dir/templates/deployment.yml"
+        )
+
+        for file in "${required_files[@]}"; do
+          if [[ ! -f "$file" ]]; then
+            echo "Error: required file not found: $file" >&2
+            exit 1
+          fi
+        done
+
+    - name: Deploy with Helm
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        chart_dir="kubernetes/worker-service"
+        helm_args=(
+          --set "app_name=${{ inputs.app-name }}"
+          --set "app_image=${{ inputs.image-name }}"
+          --set-string "dockersecret=${{ inputs.dockercfg }}"
+          --set "replica_count=${{ inputs.replica-count }}"
+        )
+
+        if [[ -n "${{ inputs.deployment-vars }}" && -f "${{ inputs.deployment-vars }}" ]]; then
+          helm_args+=(--values "${{ inputs.deployment-vars }}")
+        fi
+
+        helm upgrade \
+          --install \
+          --namespace "${{ inputs.namespace }}" \
+          --create-namespace \
+          "${{ inputs.app-name }}" \
+          "$chart_dir" \
+          "${helm_args[@]}" \
+          --atomic \
+          --kubeconfig kubeconfig
+
+    - name: Output deployment summary
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        {
+          echo "### ${{ inputs.app-name }} deployment"
+          echo
+          echo "- Status: success"
+          echo "- Docker image: \`${{ inputs.image-name }}\`"
+          echo
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/resolve-service-vars/action.yml
+++ b/.github/actions/resolve-service-vars/action.yml
@@ -1,0 +1,78 @@
+name: Resolve Service Variables
+description: Resolve deterministic deployment variables for the watcher service
+
+inputs:
+  service:
+    description: Service name (watcher)
+    required: true
+  app-name-prefix:
+    description: Base application name prefix
+    required: true
+  registry:
+    description: Container registry host
+    required: true
+  docker-registry-prefix:
+    description: Registry namespace/prefix
+    required: true
+  branch:
+    description: Git branch name (dev or main)
+    required: true
+  sha:
+    description: Git commit SHA
+    required: true
+
+outputs:
+  app_name:
+    description: Kubernetes app name
+    value: ${{ steps.resolve.outputs.app_name }}
+  image_name:
+    description: Image name without registry/tag
+    value: ${{ steps.resolve.outputs.image_name }}
+  image_tag:
+    description: Short image tag derived from SHA
+    value: ${{ steps.resolve.outputs.image_tag }}
+  full_image:
+    description: Fully qualified image reference
+    value: ${{ steps.resolve.outputs.full_image }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        service="${{ inputs.service }}"
+        branch="${{ inputs.branch }}"
+        sha="${{ inputs.sha }}"
+
+        case "$service" in
+          watcher)
+            ;;
+          *)
+            echo "Unsupported service: ${service}. Expected watcher." >&2
+            exit 1
+            ;;
+        esac
+
+        case "$branch" in
+          dev|main)
+            ;;
+          *)
+            echo "Unsupported branch: ${branch}. Expected dev or main." >&2
+            exit 1
+            ;;
+        esac
+
+        app_name="${{ inputs.app-name-prefix }}-${service}-${branch}"
+        image_name="${app_name}"
+        image_tag="${sha::7}"
+        full_image="${{ inputs.registry }}/${{ inputs.docker-registry-prefix }}/${image_name}:${image_tag}"
+
+        {
+          echo "app_name=${app_name}"
+          echo "image_name=${image_name}"
+          echo "image_tag=${image_tag}"
+          echo "full_image=${full_image}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,411 @@
+name: Deployment
+
+on:
+  push:
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ${{ vars.GITLAB_REGISTRY }}
+  DOCKER_REGISTRY_PREFIX: ${{ vars.DOCKER_REGISTRY_PREFIX || 'mpib/chm/common/base-images' }}
+  NAMESPACE: ${{ vars.K8S_NAMESPACE || 'elderbot' }}
+
+jobs:
+  build-images:
+    name: Build Image (${{ matrix.service }})
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: watcher
+            build_context: .
+            dockerfile: Dockerfile.monitoring
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve service variables
+        id: vars
+        uses: ./.github/actions/resolve-service-vars
+        with:
+          service: ${{ matrix.service }}
+          app-name-prefix: ${{ vars.APP_NAME }}
+          registry: ${{ env.REGISTRY }}
+          docker-registry-prefix: ${{ env.DOCKER_REGISTRY_PREFIX }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GITLAB_REGISTRY_USERNAME }}
+          password: ${{ secrets.GITLAB_REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.build_context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.vars.outputs.full_image }}
+          provenance: false
+
+      - name: Write build metadata
+        if: always()
+        shell: bash
+        env:
+          SERVICE: ${{ matrix.service }}
+          BRANCH: ${{ github.ref_name }}
+          BUILD_STATUS: ${{ job.status }}
+          APP_NAME: ${{ steps.vars.outputs.app_name }}
+          IMAGE_NAME: ${{ steps.vars.outputs.image_name }}
+          IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
+          FULL_IMAGE: ${{ steps.vars.outputs.full_image }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p build-meta
+
+          {
+            echo "service=${SERVICE}"
+            echo "branch=${BRANCH}"
+            echo "build_status=${BUILD_STATUS}"
+            echo "app_name=${APP_NAME:-n/a}"
+            echo "image_name=${IMAGE_NAME:-n/a}"
+            echo "image_tag=${IMAGE_TAG:-n/a}"
+            echo "full_image=${FULL_IMAGE:-n/a}"
+          } > "build-meta/${SERVICE}.env"
+
+      - name: Upload build metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-meta-${{ matrix.service }}
+          path: build-meta/${{ matrix.service }}.env
+          if-no-files-found: error
+
+  deploy-services:
+    name: Deploy Service (${{ matrix.service }})
+    runs-on: self-hosted
+    needs: build-images
+    if: always()
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - service: watcher
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build metadata
+        id: download_build_meta
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: build-meta-${{ matrix.service }}
+          path: build-meta
+
+      - name: Evaluate build result
+        id: build_gate
+        if: always()
+        shell: bash
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          set -euo pipefail
+
+          file="build-meta/${SERVICE}.env"
+          should_deploy="false"
+          build_status="failure"
+          branch="${GITHUB_REF_NAME}"
+          image_tag="n/a"
+          full_image="n/a"
+
+          if [[ -f "$file" ]]; then
+            read_meta_value() {
+              local key="$1"
+              awk -F= -v k="$key" '$1 == k { print substr($0, index($0, "=") + 1); exit }' "$file"
+            }
+
+            build_status="$(read_meta_value build_status)"
+            branch="$(read_meta_value branch)"
+            image_tag="$(read_meta_value image_tag)"
+            full_image="$(read_meta_value full_image)"
+          else
+            echo "Missing build metadata file: $file" >&2
+          fi
+
+          build_status="${build_status:-failure}"
+          branch="${branch:-${GITHUB_REF_NAME}}"
+          image_tag="${image_tag:-n/a}"
+          full_image="${full_image:-n/a}"
+
+          if [[ "$build_status" == "success" ]]; then
+            should_deploy="true"
+          fi
+
+          {
+            echo "should_deploy=${should_deploy}"
+            echo "build_status=${build_status}"
+            echo "branch=${branch}"
+            echo "image_tag=${image_tag}"
+            echo "full_image=${full_image}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve service variables
+        id: vars
+        if: steps.build_gate.outputs.should_deploy == 'true'
+        uses: ./.github/actions/resolve-service-vars
+        with:
+          service: ${{ matrix.service }}
+          app-name-prefix: ${{ vars.APP_NAME }}
+          registry: ${{ env.REGISTRY }}
+          docker-registry-prefix: ${{ env.DOCKER_REGISTRY_PREFIX }}
+          branch: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
+
+      - name: Create watcher deployment variables
+        if: steps.build_gate.outputs.should_deploy == 'true' && matrix.service == 'watcher'
+        shell: bash
+        env:
+          MONGODB_URI_DEV: ${{ secrets.MONGODB_URI_DEV }}
+          MONGODB_URI_MAIN: ${{ secrets.MONGODB_URI_MAIN }}
+          MONGODB_DATABASE_DEV: ${{ vars.MONGODB_DATABASE_DEV }}
+          MONGODB_DATABASE_MAIN: ${{ vars.MONGODB_DATABASE_MAIN }}
+          OPENAI_MODERATION_API_KEY: ${{ secrets.OPENAI_MODERATION_API_KEY }}
+          LLAMA_GUARD_API_KEY: ${{ secrets.LLAMA_GUARD_API_KEY }}
+          LLAMA_GUARD_ENDPOINT: ${{ vars.LLAMA_GUARD_ENDPOINT }}
+          MONGODB_COLLECTION: ${{ vars.MONGODB_COLLECTION || 'Conversations' }}
+          MONGODB_CHANGE_STREAM_MAX_AWAIT_MS: ${{ vars.MONGODB_CHANGE_STREAM_MAX_AWAIT_MS || '1000' }}
+          MONGODB_BACKFILL_BATCH_SIZE: ${{ vars.MONGODB_BACKFILL_BATCH_SIZE || '200' }}
+          MONGODB_BACKFILL_MAX_RETRIES: ${{ vars.MONGODB_BACKFILL_MAX_RETRIES || '10' }}
+          MONGODB_BACKFILL_RETRY_SLEEP_SECONDS: ${{ vars.MONGODB_BACKFILL_RETRY_SLEEP_SECONDS || '2' }}
+          MONGODB_RECONNECT_BACKOFF_BASE_SECONDS: ${{ vars.MONGODB_RECONNECT_BACKOFF_BASE_SECONDS || '1' }}
+          MONGODB_RECONNECT_BACKOFF_MAX_SECONDS: ${{ vars.MONGODB_RECONNECT_BACKOFF_MAX_SECONDS || '30' }}
+          MONGODB_RECONNECT_BACKOFF_JITTER_SECONDS: ${{ vars.MONGODB_RECONNECT_BACKOFF_JITTER_SECONDS || '0.25' }}
+          HPMS_LOG_LEVEL: ${{ vars.HPMS_LOG_LEVEL || 'INFO' }}
+        run: |
+          set -euo pipefail
+
+          branch="${GITHUB_REF##*/}"
+          case "$branch" in
+            dev)
+              mongodb_uri="$MONGODB_URI_DEV"
+              mongodb_database="$MONGODB_DATABASE_DEV"
+              ;;
+            main)
+              mongodb_uri="$MONGODB_URI_MAIN"
+              mongodb_database="$MONGODB_DATABASE_MAIN"
+              ;;
+            *)
+              echo "Unsupported branch: ${branch}" >&2
+              exit 1
+              ;;
+          esac
+
+          [[ -n "$mongodb_uri" ]] || {
+            echo "Missing MongoDB URI for branch: ${branch}" >&2
+            exit 1
+          }
+          [[ -n "$mongodb_database" ]] || {
+            echo "Missing MongoDB database for branch: ${branch}" >&2
+            exit 1
+          }
+          [[ -n "$OPENAI_MODERATION_API_KEY" ]] || {
+            echo "Missing OPENAI_MODERATION_API_KEY secret" >&2
+            exit 1
+          }
+          [[ -n "$LLAMA_GUARD_API_KEY" ]] || {
+            echo "Missing LLAMA_GUARD_API_KEY secret" >&2
+            exit 1
+          }
+          [[ -n "$LLAMA_GUARD_ENDPOINT" ]] || {
+            echo "Missing LLAMA_GUARD_ENDPOINT variable" >&2
+            exit 1
+          }
+
+          cat > /tmp/deployment_vars.yml <<EOV
+          deployment_vars:
+            MONGODB_URI: "$mongodb_uri"
+            MONGODB_DATABASE: "$mongodb_database"
+            MONGODB_COLLECTION: "$MONGODB_COLLECTION"
+            MONGODB_CHANGE_STREAM_MAX_AWAIT_MS: "$MONGODB_CHANGE_STREAM_MAX_AWAIT_MS"
+            MONGODB_BACKFILL_BATCH_SIZE: "$MONGODB_BACKFILL_BATCH_SIZE"
+            MONGODB_BACKFILL_MAX_RETRIES: "$MONGODB_BACKFILL_MAX_RETRIES"
+            MONGODB_BACKFILL_RETRY_SLEEP_SECONDS: "$MONGODB_BACKFILL_RETRY_SLEEP_SECONDS"
+            MONGODB_RECONNECT_BACKOFF_BASE_SECONDS: "$MONGODB_RECONNECT_BACKOFF_BASE_SECONDS"
+            MONGODB_RECONNECT_BACKOFF_MAX_SECONDS: "$MONGODB_RECONNECT_BACKOFF_MAX_SECONDS"
+            MONGODB_RECONNECT_BACKOFF_JITTER_SECONDS: "$MONGODB_RECONNECT_BACKOFF_JITTER_SECONDS"
+            HPMS_LOG_LEVEL: "$HPMS_LOG_LEVEL"
+            OPENAI_MODERATION_API_KEY: "$OPENAI_MODERATION_API_KEY"
+            LLAMA_GUARD_API_KEY: "$LLAMA_GUARD_API_KEY"
+            LLAMA_GUARD_ENDPOINT: "$LLAMA_GUARD_ENDPOINT"
+          EOV
+
+      - name: Deploy with Helm
+        id: deploy
+        if: steps.build_gate.outputs.should_deploy == 'true'
+        uses: ./.github/actions/deploy-helm
+        with:
+          app-name: ${{ steps.vars.outputs.app_name }}
+          image-name: ${{ steps.vars.outputs.full_image }}
+          namespace: ${{ env.NAMESPACE }}
+          replica-count: ${{ vars.WATCHER_REPLICA_COUNT || '1' }}
+          deployment-vars: /tmp/deployment_vars.yml
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+          dockercfg: ${{ secrets.DOCKERCFG }}
+
+      - name: Write deploy metadata
+        if: always()
+        shell: bash
+        env:
+          SERVICE: ${{ matrix.service }}
+          BRANCH: ${{ github.ref_name }}
+          GATE_BRANCH: ${{ steps.build_gate.outputs.branch }}
+          BUILD_STATUS: ${{ steps.build_gate.outputs.build_status }}
+          SHOULD_DEPLOY: ${{ steps.build_gate.outputs.should_deploy }}
+          BUILD_IMAGE_TAG: ${{ steps.build_gate.outputs.image_tag }}
+          BUILD_FULL_IMAGE: ${{ steps.build_gate.outputs.full_image }}
+          RESOLVED_IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
+          RESOLVED_FULL_IMAGE: ${{ steps.vars.outputs.full_image }}
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p deploy-meta
+
+          deploy_status="skipped"
+          if [[ "${SHOULD_DEPLOY:-false}" == "true" ]]; then
+            case "${DEPLOY_OUTCOME:-}" in
+              success)
+                deploy_status="success"
+                ;;
+              failure)
+                deploy_status="failure"
+                ;;
+              cancelled)
+                deploy_status="cancelled"
+                ;;
+              skipped|"")
+                deploy_status="failure"
+                ;;
+              *)
+                deploy_status="${DEPLOY_OUTCOME}"
+                ;;
+            esac
+          fi
+
+          branch="${GATE_BRANCH:-${BRANCH}}"
+          image_tag="${BUILD_IMAGE_TAG:-n/a}"
+          full_image="${BUILD_FULL_IMAGE:-n/a}"
+
+          if [[ "${SHOULD_DEPLOY:-false}" == "true" ]]; then
+            image_tag="${RESOLVED_IMAGE_TAG:-${image_tag}}"
+            full_image="${RESOLVED_FULL_IMAGE:-${full_image}}"
+          fi
+
+          {
+            echo "service=${SERVICE}"
+            echo "branch=${branch}"
+            echo "build_status=${BUILD_STATUS:-failure}"
+            echo "deploy_status=${deploy_status}"
+            echo "should_deploy=${SHOULD_DEPLOY:-false}"
+            echo "image_tag=${image_tag}"
+            echo "full_image=${full_image}"
+          } > "deploy-meta/${SERVICE}.env"
+
+      - name: Upload deploy metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-meta-${{ matrix.service }}
+          path: deploy-meta/${{ matrix.service }}.env
+          if-no-files-found: error
+
+  deployment-summary:
+    name: Deployment Summary
+    runs-on: self-hosted
+    needs: [build-images, deploy-services]
+    if: always()
+
+    steps:
+      - name: Download deployment metadata
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: deploy-meta-*
+          path: deploy-meta
+          merge-multiple: true
+
+      - name: Write summary
+        shell: bash
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          status_icon() {
+            case "$1" in
+              success) echo "[ok]" ;;
+              failure) echo "[fail]" ;;
+              cancelled) echo "[cancelled]" ;;
+              skipped) echo "[skipped]" ;;
+              *) echo "[unknown]" ;;
+            esac
+          }
+
+          read_meta_value() {
+            local file="$1"
+            local key="$2"
+
+            if [[ ! -f "$file" ]]; then
+              return
+            fi
+
+            awk -F= -v k="$key" '$1 == k { print substr($0, index($0, "=") + 1); exit }' "$file"
+          }
+
+          file="deploy-meta/watcher.env"
+          branch="${BRANCH}"
+          build_status="unknown"
+          deploy_status="unknown"
+          image_tag="n/a"
+          full_image="n/a"
+
+          if [[ -f "$file" ]]; then
+            branch="$(read_meta_value "$file" branch)"
+            build_status="$(read_meta_value "$file" build_status)"
+            deploy_status="$(read_meta_value "$file" deploy_status)"
+            image_tag="$(read_meta_value "$file" image_tag)"
+            full_image="$(read_meta_value "$file" full_image)"
+          fi
+
+          branch="${branch:-${BRANCH}}"
+          build_status="${build_status:-unknown}"
+          deploy_status="${deploy_status:-unknown}"
+          image_tag="${image_tag:-n/a}"
+          full_image="${full_image:-n/a}"
+
+          {
+            echo "## Deployment Summary"
+            echo
+            echo "| Service | Build Status | Deploy Status | Branch | Image Tag | Image |"
+            echo "|---------|--------------|---------------|--------|-----------|-------|"
+            echo "| Watcher | $(status_icon "$build_status") ${build_status} | $(status_icon "$deploy_status") ${deploy_status} | ${branch} | \`${image_tag}\` | \`${full_image}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^kubernetes/.+/templates/.+\.ya?ml$
       - id: check-added-large-files
       - id: check-toml
       - id: debug-statements
@@ -16,6 +17,7 @@ repos:
       - id: mixed-line-ending
       - id: requirements-txt-fixer
       - id: sort-simple-yaml
+        exclude: ^kubernetes/.+/templates/.+\.ya?ml$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1

--- a/docs/ci-cd-deployment.md
+++ b/docs/ci-cd-deployment.md
@@ -1,0 +1,129 @@
+# CI/CD Deployment (GitHub Actions + Helm)
+
+This repository deploys the monitoring `watcher` service through GitHub Actions by building a Docker image and deploying it to Kubernetes with Helm.
+
+## Workflow Architecture
+
+- Workflow: [`../.github/workflows/deployment.yml`](../.github/workflows/deployment.yml)
+- Composite action (vars): [`../.github/actions/resolve-service-vars/action.yml`](../.github/actions/resolve-service-vars/action.yml)
+- Composite action (deploy): [`../.github/actions/deploy-helm/action.yml`](../.github/actions/deploy-helm/action.yml)
+- Helm chart: [`../kubernetes/worker-service`](../kubernetes/worker-service)
+
+The workflow runs build and deploy pipelines for `watcher` and then writes a deployment summary.
+
+## Branches and Triggers
+
+Supported deployment branches:
+
+- `dev`
+- `main`
+
+Workflow triggers:
+
+- push to `dev` or `main`
+- manual dispatch (`workflow_dispatch`)
+
+## Runner and Environment Model
+
+- All jobs run on `self-hosted` runners.
+- Global workflow environment:
+  - `REGISTRY`: `${{ vars.GITLAB_REGISTRY }}`
+  - `DOCKER_REGISTRY_PREFIX`: `${{ vars.DOCKER_REGISTRY_PREFIX || 'mpib/chm/common/base-images' }}`
+  - `NAMESPACE`: `${{ vars.K8S_NAMESPACE || 'elderbot' }}`
+
+## Build and Deploy Logic
+
+The `watcher` service follows this flow:
+
+1. Resolve deterministic app/image naming (`<APP_NAME>-watcher-<branch>`).
+1. Build and push Docker image from `Dockerfile.monitoring`.
+1. Generate `/tmp/deployment_vars.yml` for runtime environment values.
+1. Deploy with local `deploy-helm` composite action.
+
+### Runtime deployment variables
+
+The workflow writes this contract into `/tmp/deployment_vars.yml`:
+
+Required values:
+
+- `MONGODB_URI` (branch-specific: `MONGODB_URI_DEV`/`MONGODB_URI_MAIN`)
+- `MONGODB_DATABASE` (branch-specific: `MONGODB_DATABASE_DEV`/`MONGODB_DATABASE_MAIN`)
+- `OPENAI_MODERATION_API_KEY`
+- `LLAMA_GUARD_API_KEY`
+- `LLAMA_GUARD_ENDPOINT`
+
+Optional values with defaults:
+
+- `MONGODB_COLLECTION` (`Conversations`)
+- `MONGODB_CHANGE_STREAM_MAX_AWAIT_MS` (`1000`)
+- `MONGODB_BACKFILL_BATCH_SIZE` (`200`)
+- `MONGODB_BACKFILL_MAX_RETRIES` (`10`)
+- `MONGODB_BACKFILL_RETRY_SLEEP_SECONDS` (`2`)
+- `MONGODB_RECONNECT_BACKOFF_BASE_SECONDS` (`1`)
+- `MONGODB_RECONNECT_BACKOFF_MAX_SECONDS` (`30`)
+- `MONGODB_RECONNECT_BACKOFF_JITTER_SECONDS` (`0.25`)
+- `HPMS_LOG_LEVEL` (`INFO`)
+
+## Required GitHub Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `GITLAB_REGISTRY` | Docker registry host |
+| `APP_NAME` | Application name prefix used in image/release naming |
+| `LLAMA_GUARD_ENDPOINT` | Llama Guard endpoint URL |
+| `MONGODB_DATABASE_DEV` | MongoDB database name for `dev` deployments |
+| `MONGODB_DATABASE_MAIN` | MongoDB database name for `main` deployments |
+
+Optional variables:
+
+- `DOCKER_REGISTRY_PREFIX` (default `mpib/chm/common/base-images`)
+- `K8S_NAMESPACE` (default `elderbot`)
+- `WATCHER_REPLICA_COUNT` (default `1`)
+- watcher tuning variables listed above
+
+## Required GitHub Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `GITLAB_REGISTRY_USERNAME` | Registry authentication |
+| `GITLAB_REGISTRY_PASSWORD` | Registry authentication |
+| `KUBECONFIG` | Base64-encoded kubeconfig used for Helm deployment |
+| `DOCKERCFG` | Base64 Docker config JSON for Kubernetes image pull secret |
+| `MONGODB_URI_DEV` | Watcher MongoDB URI for `dev` deployments |
+| `MONGODB_URI_MAIN` | Watcher MongoDB URI for `main` deployments |
+| `OPENAI_MODERATION_API_KEY` | OpenAI moderation key used by watcher |
+| `LLAMA_GUARD_API_KEY` | Llama Guard API key used by watcher |
+
+## Kubernetes Chart Contract
+
+The chart in `kubernetes/worker-service` defines a worker deployment contract with:
+
+- image pull `Secret` (`kubernetes.io/dockerconfigjson`)
+- `Deployment`
+
+The worker chart intentionally does not create `Service` or `Ingress` resources because the watcher is a background consumer and not an HTTP service.
+
+Required chart values provided by workflow/action:
+
+- `app_name`
+- `app_image`
+- `dockersecret`
+- `replica_count`
+
+Runtime env values are passed through `deployment_vars` from `/tmp/deployment_vars.yml`.
+
+## Deployment Summary
+
+The final `deployment-summary` job always runs and writes one watcher row with:
+
+- build status
+- deploy status
+- branch
+- image tag and full image reference
+
+## Troubleshooting
+
+- Missing chart files: check `kubernetes/worker-service` exists in the repository.
+- Registry auth failures: verify `GITLAB_REGISTRY_USERNAME` and `GITLAB_REGISTRY_PASSWORD`.
+- Kubernetes auth failures: verify `KUBECONFIG` is valid base64 kubeconfig content.
+- Missing watcher env values: verify required variables and secrets are configured in GitHub repository settings.

--- a/kubernetes/worker-service/Chart.yaml
+++ b/kubernetes/worker-service/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: worker-service
+description: Deploy a background worker
+version: 1.0.0

--- a/kubernetes/worker-service/templates/deployment.yml
+++ b/kubernetes/worker-service/templates/deployment.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.app_name }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.dockersecret }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.app_name }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}
+    helm.sh/deploymentname: {{ .Values.app_name }}
+spec:
+  replicas: {{ .Values.replica_count }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app_name }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      labels:
+        app: {{ .Values.app_name }}
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: {{ .Values.app_name }}
+          image: {{ .Values.app_image }}
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: {{ .Values.resources.requests.memory | default "256Mi" | quote }}
+              cpu: {{ .Values.resources.requests.cpu | default "100m" | quote }}
+            limits:
+              memory: {{ .Values.resources.limits.memory | default "1Gi" | quote }}
+              cpu: {{ .Values.resources.limits.cpu | default "1" | quote }}
+          {{- if .Values.deployment_vars }}
+          env:
+            {{- range $key, $val := .Values.deployment_vars }}
+            - name: {{ $key | quote }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- end }}
+      imagePullSecrets:
+        - name: {{ .Values.app_name }}

--- a/kubernetes/worker-service/values.yaml
+++ b/kubernetes/worker-service/values.yaml
@@ -1,0 +1,8 @@
+resources:
+  requests: {}
+  limits: {}
+app_name: ""
+app_image: ""
+dockersecret: ""
+replica_count: 1
+deployment_vars: {}

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ errors for `mongo`.
 - Architecture Decision Record (ADR) for compose split and local monitoring stack: [BAN-24 compose restructure](./docs/adr/2026-03-02-ban-24-compose-restructure-local-monitoring.md)
 - ADR for Mongo schema alignment and realtime watcher: [BAN-24 schema and watcher](./docs/adr/2026-03-02-ban-24-hpms-mongo-schema-alignment-and-realtime-monitoring.md)
 - Paper data workflow: [paper-data-workflow.md](./docs/paper-data-workflow.md)
+- CI/CD deployment: [ci-cd-deployment.md](./docs/ci-cd-deployment.md)
 - Contribution guide: [contributing.md](./contributing.md)
 
 ## Related


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and deploy the watcher service on `dev` and `main`
- add local composite actions plus a worker-only Helm chart under `kubernetes/`
- document the CI/CD contract and link it from the README

## Validation
- `poetry run pre-commit run --files .pre-commit-config.yaml .github/workflows/deployment.yml .github/actions/resolve-service-vars/action.yml .github/actions/deploy-helm/action.yml kubernetes/worker-service/Chart.yaml kubernetes/worker-service/values.yaml kubernetes/worker-service/templates/deployment.yml docs/ci-cd-deployment.md readme.md`
- `helm template hpms-watcher-dev kubernetes/worker-service --set app_name=hpms-watcher-dev --set app_image=example/image:tag --set-string dockersecret=dummy`

## Tracking
- BAN-102
- BAN-103