### PR TITLE
Backend: Normalize blank reviewer fields

### DIFF
--- a/hpms/database/models.py
+++ b/hpms/database/models.py
@@ -3,10 +3,54 @@
 from datetime import datetime
 from typing import Any, List, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
-class UserFlagReviewDocument(BaseModel):
+# pylint: disable=too-few-public-methods
+class _BlankOptionalIdentityFieldMixin:
+    """Normalize blank optional identity fields to ``None``."""
+
+    @field_validator(
+        "reviewer_username",
+        "created_by",
+        "reviewer_by_username",
+        "flagged_by",
+        mode="before",
+        check_fields=False,
+    )
+    @classmethod
+    def blank_optional_identity_field_to_none(cls, value: Any) -> Any:
+        """Treat blank legacy identity strings as missing values."""
+        if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
+
+class _NonBlankRequiredIdentityFieldMixin:
+    """Reject whitespace-only values for required identity fields."""
+
+    @field_validator(
+        "reviewer_id",
+        "participant_id",
+        "experiment_id",
+        "conversation_id",
+        "project_id",
+        mode="before",
+        check_fields=False,
+    )
+    @classmethod
+    def reject_blank_required_identity_field(cls, value: Any) -> Any:
+        """Ensure required identity fields contain a non-whitespace value."""
+        if isinstance(value, str) and not value.strip():
+            raise ValueError("Value must contain at least 1 non-whitespace character")
+        return value
+
+
+class UserFlagReviewDocument(
+    _BlankOptionalIdentityFieldMixin, _NonBlankRequiredIdentityFieldMixin, BaseModel
+):
     """Review of a participant flag by a human reviewer."""
 
     model_config = ConfigDict(extra="forbid")
@@ -18,7 +62,7 @@ class UserFlagReviewDocument(BaseModel):
     reviewed_at: datetime
 
 
-class UserFlagDocument(BaseModel):
+class UserFlagDocument(_BlankOptionalIdentityFieldMixin, BaseModel):
     """Participant-created flag on a single message."""
 
     model_config = ConfigDict(extra="forbid")
@@ -30,7 +74,9 @@ class UserFlagDocument(BaseModel):
     reviews: List[UserFlagReviewDocument] = Field(default_factory=list)
 
 
-class ReviewerFlagDocument(BaseModel):
+class ReviewerFlagDocument(
+    _BlankOptionalIdentityFieldMixin, _NonBlankRequiredIdentityFieldMixin, BaseModel
+):
     """Reviewer-created flag on a single message."""
 
     model_config = ConfigDict(extra="forbid")
@@ -43,7 +89,9 @@ class ReviewerFlagDocument(BaseModel):
     comment: str = ""
 
 
-class DuplicateFlagDocument(BaseModel):
+class DuplicateFlagDocument(
+    _BlankOptionalIdentityFieldMixin, _NonBlankRequiredIdentityFieldMixin, BaseModel
+):
     """Duplicate flag metadata for a single message."""
 
     model_config = ConfigDict(extra="forbid")
@@ -53,7 +101,7 @@ class DuplicateFlagDocument(BaseModel):
     flagged_at: datetime
 
 
-class MessageDocument(BaseModel):
+class MessageDocument(_BlankOptionalIdentityFieldMixin, BaseModel):
     """Message document embedded in a conversation."""
 
     model_config = ConfigDict(extra="forbid")
@@ -72,7 +120,7 @@ class MessageDocument(BaseModel):
     duplicate_flags: List[DuplicateFlagDocument] = Field(default_factory=list)
 
 
-class OpenedByDocument(BaseModel):
+class OpenedByDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """Reviewer open-state entry."""
 
     model_config = ConfigDict(extra="forbid")
@@ -81,7 +129,7 @@ class OpenedByDocument(BaseModel):
     opened_at: datetime
 
 
-class ReviewedByDocument(BaseModel):
+class ReviewedByDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """Reviewer reviewed-state entry."""
 
     model_config = ConfigDict(extra="forbid")
@@ -90,7 +138,7 @@ class ReviewedByDocument(BaseModel):
     reviewed_at: datetime
 
 
-class ConversationAssignmentDocument(BaseModel):
+class ConversationAssignmentDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """Assignment metadata for a reviewer and conversation."""
 
     model_config = ConfigDict(extra="forbid")
@@ -100,7 +148,7 @@ class ConversationAssignmentDocument(BaseModel):
     assigned_at: datetime
 
 
-class NaturalnessRatingDocument(BaseModel):
+class NaturalnessRatingDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """Naturalness rating metadata for a conversation."""
 
     model_config = ConfigDict(extra="forbid")
@@ -111,7 +159,7 @@ class NaturalnessRatingDocument(BaseModel):
     rated_at: datetime
 
 
-class RealismRatingDocument(BaseModel):
+class RealismRatingDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """Realism rating metadata for a conversation."""
 
     model_config = ConfigDict(extra="forbid")
@@ -121,7 +169,7 @@ class RealismRatingDocument(BaseModel):
     rated_at: datetime
 
 
-class ConversationDocument(BaseModel):
+class ConversationDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """MongoDB conversation document matching the dashboard schema."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -366,6 +366,49 @@ def test_get_backfill_targets_accepts_simple_chat_fields():
     }
 
 
+def test_get_backfill_targets_accepts_blank_optional_reviewer_identity_fields():
+    now = datetime.now(timezone.utc)
+    conversation = {
+        "_id": "conversation-blank-reviewer-username",
+        "participant_id": "p5",
+        "model": "test-model",
+        "experiment_id": "exp-5",
+        "conversation_id": "conversation-blank-reviewer-username",
+        "project_id": "2026_03_09",
+        "created_at": now,
+        "messages": [
+            {
+                "content": "message with legacy reviewer username",
+                "role": "assistant",
+                "timestamp": now,
+                "type": "assistant",
+                "reviewer_flags": [
+                    {
+                        "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
+                        "reviewer_by_username": "",
+                        "created_at": now,
+                        "categories": ["violence"],
+                        "category_other": "",
+                        "comment": "",
+                    }
+                ],
+            }
+        ],
+        "opened_by": [],
+        "reviewed_by": [],
+        "assigned_to": [],
+    }
+
+    repository = MongoConversationRepository.from_collection(FakeCollection([conversation]))
+
+    targets = repository.get_backfill_targets(batch_size=10)
+
+    assert len(targets) == 1
+    assert targets[0].conversation_id == "conversation-blank-reviewer-username"
+    assert targets[0].message_index == 0
+    assert targets[0].missing_reviewer_ids == {SYSTEM_LLAMA_REVIEWER_ID}
+
+
 def test_conversation_document_accepts_canonical_extended_fields():
     now = datetime.now(timezone.utc)
     document = ConversationDocument.model_validate(
@@ -444,6 +487,70 @@ def test_conversation_document_accepts_canonical_extended_fields():
     assert document.messages[0].duplicate_flags[0].reviewer_username == "carol"
     assert document.naturalness_ratings[0].coherence == 5
     assert document.realism_ratings[0].rating == 10
+
+
+def test_conversation_document_normalizes_blank_optional_identity_fields():
+    now = datetime.now(timezone.utc)
+    document = ConversationDocument.model_validate(
+        {
+            "_id": "conversation-blank-optional-fields",
+            "participant_id": "p7",
+            "model": "test-model",
+            "experiment_id": "exp-7",
+            "conversation_id": "conversation-blank-optional-fields",
+            "project_id": "2026_03_09",
+            "created_at": now,
+            "messages": [
+                {
+                    "content": "message with blank optional identity fields",
+                    "role": "assistant",
+                    "timestamp": now,
+                    "type": "assistant",
+                    "flagged_by": "   ",
+                    "user_flag": {
+                        "category": "harassment",
+                        "category_other": "",
+                        "created_by": "",
+                        "reviews": [
+                            {
+                                "reviewer_id": "reviewer-1",
+                                "reviewer_username": " ",
+                                "approved": True,
+                                "comment": "",
+                                "reviewed_at": now,
+                            }
+                        ],
+                    },
+                    "reviewer_flags": [
+                        {
+                            "reviewer_id": "reviewer-2",
+                            "reviewer_by_username": "",
+                            "created_at": now,
+                            "categories": [],
+                            "category_other": "",
+                            "comment": "",
+                        }
+                    ],
+                    "duplicate_flags": [
+                        {
+                            "reviewer_id": "reviewer-3",
+                            "reviewer_username": "   ",
+                            "flagged_at": now,
+                        }
+                    ],
+                }
+            ],
+            "opened_by": [],
+            "reviewed_by": [],
+            "assigned_to": [],
+        }
+    )
+
+    assert document.messages[0].flagged_by is None
+    assert document.messages[0].user_flag.created_by is None
+    assert document.messages[0].user_flag.reviews[0].reviewer_username is None
+    assert document.messages[0].reviewer_flags[0].reviewer_by_username is None
+    assert document.messages[0].duplicate_flags[0].reviewer_username is None
 
 
 def test_conversation_document_accepts_simple_chat_compatible_shape():
@@ -558,4 +665,60 @@ def test_conversation_document_rejects_unknown_fields(mutator):
     mutator(document)
 
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ConversationDocument.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (
+            lambda document: document.update({"participant_id": ""}),
+            "participant_id",
+        ),
+        (
+            lambda document: document["messages"][0]["reviewer_flags"][0].update(
+                {"reviewer_id": " "}
+            ),
+            "reviewer_id",
+        ),
+    ],
+    ids=["blank participant_id", "blank reviewer_id"],
+)
+def test_conversation_document_rejects_blank_required_identity_fields(
+    mutator, match
+):
+    now = datetime.now(timezone.utc)
+    document = {
+        "_id": "conversation-required-identities",
+        "participant_id": "p8",
+        "model": "test-model",
+        "experiment_id": "exp-8",
+        "conversation_id": "conversation-required-identities",
+        "project_id": "2026_03_09",
+        "created_at": now,
+        "messages": [
+            {
+                "content": "message",
+                "role": "assistant",
+                "timestamp": now,
+                "type": "assistant",
+                "reviewer_flags": [
+                    {
+                        "reviewer_id": "reviewer-1",
+                        "created_at": now,
+                        "categories": [],
+                        "category_other": "",
+                        "comment": "",
+                    }
+                ],
+            }
+        ],
+        "opened_by": [],
+        "reviewed_by": [],
+        "assigned_to": [],
+    }
+
+    mutator(document)
+
+    with pytest.raises(ValidationError, match=match):
         ConversationDocument.model_validate(document)

--- a/tests/test_realtime_watcher.py
+++ b/tests/test_realtime_watcher.py
@@ -348,6 +348,52 @@ def test_handle_change_event_defaults_missing_user_flag_and_processes_message():
     assert all(call.message_index == 0 for call in repository.calls)
 
 
+def test_handle_change_event_accepts_blank_optional_reviewer_identity_fields():
+    repository = StubRepository()
+
+    watcher = RealtimeConversationWatcher(
+        repository=repository,
+        openai_rater=lambda _text: [0, "hate"],
+        llama_guard_rater=lambda _text: "0",
+    )
+
+    event = {
+        "operationType": "insert",
+        "fullDocument": {
+            "_id": "conversation-blank-reviewer-username",
+            "participant_id": "p1",
+            "model": "test-model",
+            "experiment_id": "exp-1",
+            "conversation_id": "conversation-blank-reviewer-username",
+            "project_id": "2026_03_08",
+            "created_at": "2026-03-02T00:00:00Z",
+            "messages": [
+                _message(
+                    "needs one remaining rating",
+                    [
+                        {
+                            "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
+                            "reviewer_by_username": "",
+                            "created_at": "2026-03-02T00:00:00Z",
+                            "categories": [],
+                            "category_other": "",
+                        }
+                    ],
+                )
+            ],
+            "opened_by": [],
+            "reviewed_by": [],
+            "assigned_to": [],
+        },
+    }
+
+    watcher.handle_change_event(event)
+
+    assert len(repository.calls) == 1
+    assert repository.calls[0].message_index == 0
+    assert repository.calls[0].reviewer_id == SYSTEM_LLAMA_REVIEWER_ID
+
+
 def test_handle_change_event_defaults_missing_optional_message_and_conversation_lists():
     repository = StubRepository()
 


### PR DESCRIPTION
## Summary
- normalize blank optional identity fields in Mongo conversation schemas to `None`
- keep required identity fields strict by rejecting whitespace-only values
- add repository and realtime watcher regressions for legacy empty reviewer fields

## Validation
- `poetry run pytest tests/test_database_repository.py tests/test_realtime_watcher.py` ✅
- `poetry run pre-commit run pylint --files hpms/database/models.py tests/test_database_repository.py tests/test_realtime_watcher.py` ✅

## Notes
- committed with `git commit --no-verify` at user request after the full pre-commit commit hook stalled in the `mypy` step