### PR TITLE
Backend: Skip system message reviews

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -20,22 +20,22 @@ repos:
         exclude: ^kubernetes/.+/templates/.+\.ya?ml$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.1-beta
+    rev: v2.14.0
     hooks:
       - id: hadolint
 
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.29
+    rev: v0.1.30
     hooks:
       - id: helmlint
 
   - repo: https://github.com/pycqa/flake8
-    rev: "7.2.0" # pick a git hash / tag to point to
+    rev: "7.3.0" # pick a git hash / tag to point to
     hooks:
       - id: flake8
 
@@ -61,19 +61,19 @@ repos:
         args: ["--rcfile=.pylintrc"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.15.0"
+    rev: "v1.19.1"
     hooks:
       - id: mypy
         args: ["--config-file", ".mypy.ini"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.7
+    rev: v0.15.5
     hooks:
       # Run the linter.
       - id: ruff
@@ -84,7 +84,7 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/google/pyink
-    rev: 24.10.1
+    rev: 25.12.0
     hooks:
       - id: pyink
         # It is recommended to specify the latest version of Python

--- a/hpms/database/repository.py
+++ b/hpms/database/repository.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Optional, Set
 
 from pydantic import ValidationError
 
+from hpms.constants import SYSTEM
 from hpms.database.models import ConversationDocument, MessageDocument
 
 SYSTEM_OPENAI_REVIEWER_ID = "system_openai_moderation"
@@ -81,6 +82,11 @@ class MongoConversationRepository:
     @staticmethod
     def missing_system_reviewers(message: dict[str, Any]) -> Set[str]:
         """Return system reviewer IDs that have not yet been persisted."""
+        if not MongoConversationRepository.is_message_eligible_for_system_reviewers(
+            message
+        ):
+            return set()
+
         reviewer_flags = message.get("reviewer_flags", [])
         existing_reviewer_ids = {
             str(flag.get("reviewer_id", ""))
@@ -94,6 +100,19 @@ class MongoConversationRepository:
         if SYSTEM_LLAMA_REVIEWER_ID not in existing_reviewer_ids:
             missing.add(SYSTEM_LLAMA_REVIEWER_ID)
         return missing
+
+    @staticmethod
+    def is_message_eligible_for_system_reviewers(message: dict[str, Any]) -> bool:
+        """Return whether a message should be sent to automated reviewers."""
+        content = message.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            return False
+
+        role = message.get("role", "")
+        if not isinstance(role, str):
+            return False
+
+        return role.strip() != SYSTEM
 
     def get_backfill_targets(
         self,
@@ -136,9 +155,9 @@ class MongoConversationRepository:
             for message_index, message in enumerate(messages):
                 if not isinstance(message, dict):
                     continue
-                content = message.get("content", "")
-                if not isinstance(content, str) or not content.strip():
+                if not self.is_message_eligible_for_system_reviewers(message):
                     continue
+                content = message["content"]
 
                 missing = self.missing_system_reviewers(message)
                 missing = {
@@ -280,10 +299,10 @@ class MongoConversationRepository:
                                                                     "$let": {
                                                                         "vars": {
                                                                             "existing_flags": {
-                                                                                    "$ifNull": [
-                                                                                        "$$message.reviewer_flags",
-                                                                                        [],
-                                                                                    ]
+                                                                                "$ifNull": [
+                                                                                    "$$message.reviewer_flags",
+                                                                                    [],
+                                                                                ]
                                                                             }
                                                                         },
                                                                         "in": {
@@ -327,7 +346,9 @@ class MongoConversationRepository:
                                                                                 {
                                                                                     "$concatArrays": [
                                                                                         "$$existing_flags",
-                                                                                        ["$$new_flag"],
+                                                                                        [
+                                                                                            "$$new_flag"
+                                                                                        ],
                                                                                     ]
                                                                                 },
                                                                             ]
@@ -349,4 +370,5 @@ class MongoConversationRepository:
                 }
             }
         ]
+
     # pylint: enable=line-too-long

--- a/hpms/monitoring/realtime_watcher.py
+++ b/hpms/monitoring/realtime_watcher.py
@@ -310,14 +310,11 @@ class RealtimeConversationWatcher:
                 continue
 
             message = messages[message_index]
-            content = (
-                message.get("content", "").strip()
-                if isinstance(message, dict)
-                and isinstance(message.get("content", ""), str)
-                else ""
-            )
-            if not content:
+            if not isinstance(message, dict):
                 continue
+            if not self.repository.is_message_eligible_for_system_reviewers(message):
+                continue
+            content = message["content"]
 
             missing_reviewer_ids = self.repository.missing_system_reviewers(message)
             if not missing_reviewer_ids:

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -180,6 +180,35 @@ def test_get_backfill_targets_excludes_exhausted_provider_keys():
     assert targets[0].missing_reviewer_ids == {SYSTEM_LLAMA_REVIEWER_ID}
 
 
+def test_missing_system_reviewers_returns_empty_for_system_role_message():
+    message = _conversation_doc()["messages"][0]
+    message["role"] = "system"
+
+    missing = MongoConversationRepository.missing_system_reviewers(message)
+
+    assert missing == set()
+
+
+def test_get_backfill_targets_skips_system_role_messages():
+    conversation = _conversation_doc()
+    conversation["messages"][0]["role"] = "system"
+    conversation["messages"][1]["role"] = "user"
+    conversation["messages"][1]["reviewer_flags"] = []
+
+    repository = MongoConversationRepository.from_collection(
+        FakeCollection([conversation])
+    )
+
+    targets = repository.get_backfill_targets(batch_size=10)
+
+    assert len(targets) == 1
+    assert targets[0].message_index == 1
+    assert targets[0].missing_reviewer_ids == {
+        SYSTEM_OPENAI_REVIEWER_ID,
+        SYSTEM_LLAMA_REVIEWER_ID,
+    }
+
+
 def test_upsert_system_reviewer_flag_is_idempotent_per_message_and_provider():
     collection = FakeCollection([_conversation_doc()])
     repository = MongoConversationRepository.from_collection(collection)
@@ -399,7 +428,9 @@ def test_get_backfill_targets_accepts_blank_optional_reviewer_identity_fields():
         "assigned_to": [],
     }
 
-    repository = MongoConversationRepository.from_collection(FakeCollection([conversation]))
+    repository = MongoConversationRepository.from_collection(
+        FakeCollection([conversation])
+    )
 
     targets = repository.get_backfill_targets(batch_size=10)
 
@@ -684,9 +715,7 @@ def test_conversation_document_rejects_unknown_fields(mutator):
     ],
     ids=["blank participant_id", "blank reviewer_id"],
 )
-def test_conversation_document_rejects_blank_required_identity_fields(
-    mutator, match
-):
+def test_conversation_document_rejects_blank_required_identity_fields(mutator, match):
     now = datetime.now(timezone.utc)
     document = {
         "_id": "conversation-required-identities",

--- a/tests/test_realtime_watcher.py
+++ b/tests/test_realtime_watcher.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from datetime import datetime
 import os
 import subprocess
 import sys
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Iterable, cast
 
 import pytest
 
@@ -38,9 +39,15 @@ class _Call:
 
 
 @dataclass
-class StubRepository:
+class StubRepository(MongoConversationRepository):
     calls: list[_Call] = field(default_factory=list)
     backfill_batches: list[list[MessageBackfillTarget]] = field(default_factory=list)
+
+    @staticmethod
+    def is_message_eligible_for_system_reviewers(message: dict[str, Any]):
+        return MongoConversationRepository.is_message_eligible_for_system_reviewers(
+            message
+        )
 
     @staticmethod
     def missing_system_reviewers(message: dict[str, Any]):
@@ -54,9 +61,9 @@ class StubRepository:
 
     def get_backfill_targets(
         self,
-        batch_size: int,
+        batch_size: int = 200,
         excluded_provider_keys: set[tuple[Any, int, str]] | None = None,
-    ):
+    ) -> list[MessageBackfillTarget]:
         _ = batch_size
         _ = excluded_provider_keys
         if not self.backfill_batches:
@@ -68,17 +75,17 @@ class StubRepository:
         conversation_id: Any,
         message_index: int,
         reviewer_id: str,
-        categories: list[str],
+        categories: Iterable[str],
         category_other: str,
-        created_at,
-    ):
+        created_at: datetime | None = None,
+    ) -> None:
         _ = created_at
         self.calls.append(
             _Call(
                 conversation_id=conversation_id,
                 message_index=message_index,
                 reviewer_id=reviewer_id,
-                categories=categories,
+                categories=list(categories),
                 category_other=category_other,
             )
         )
@@ -92,9 +99,9 @@ class FilteringStubRepository(StubRepository):
 
     def get_backfill_targets(
         self,
-        batch_size: int,
+        batch_size: int = 200,
         excluded_provider_keys: set[tuple[Any, int, str]] | None = None,
-    ):
+    ) -> list[MessageBackfillTarget]:
         excluded_provider_keys = excluded_provider_keys or set()
         eligible_targets: list[MessageBackfillTarget] = []
 
@@ -130,10 +137,10 @@ class FilteringStubRepository(StubRepository):
         conversation_id: Any,
         message_index: int,
         reviewer_id: str,
-        categories: list[str],
+        categories: Iterable[str],
         category_other: str,
-        created_at,
-    ):
+        created_at: datetime | None = None,
+    ) -> None:
         super().upsert_system_reviewer_flag(
             conversation_id=conversation_id,
             message_index=message_index,
@@ -167,10 +174,15 @@ class FilteringStubRepository(StubRepository):
         self.targets = updated_targets
 
 
-def _message(content: str, reviewer_flags: list[dict[str, Any]]):
+def _message(
+    content: str,
+    reviewer_flags: list[dict[str, Any]],
+    *,
+    role: str = "assistant",
+):
     return {
         "content": content,
-        "role": "assistant",
+        "role": role,
         "timestamp": "2026-03-02T00:00:00Z",
         "type": "assistant",
         "user_flag": {
@@ -295,6 +307,89 @@ def test_handle_change_event_only_processes_messages_missing_system_flags():
                     ],
                 ),
                 _message("needs rating", []),
+            ],
+            "opened_by": [],
+            "reviewed_by": [],
+            "assigned_to": [],
+        },
+    }
+
+    watcher.handle_change_event(event)
+
+    assert len(repository.calls) == 2
+    assert all(call.message_index == 1 for call in repository.calls)
+
+
+@pytest.mark.parametrize(
+    ("operation_type", "update_description"),
+    [
+        ("insert", None),
+        (
+            "update",
+            {
+                "updatedFields": {"messages.0.content": "updated system prompt"},
+                "removedFields": [],
+            },
+        ),
+    ],
+)
+def test_handle_change_event_skips_system_role_messages(
+    operation_type: str, update_description: dict[str, Any] | None
+):
+    repository = StubRepository()
+
+    watcher = RealtimeConversationWatcher(
+        repository=repository,
+        openai_rater=lambda _text: [0, "hate"],
+        llama_guard_rater=lambda _text: "0",
+    )
+
+    event: dict[str, Any] = {
+        "operationType": operation_type,
+        "fullDocument": {
+            "_id": "conversation-system-only",
+            "participant_id": "p1",
+            "model": "test-model",
+            "experiment_id": "exp-1",
+            "conversation_id": "conversation-system-only",
+            "project_id": "2026_03_08",
+            "created_at": "2026-03-02T00:00:00Z",
+            "messages": [_message("system prompt", [], role="system")],
+            "opened_by": [],
+            "reviewed_by": [],
+            "assigned_to": [],
+        },
+    }
+    if update_description is not None:
+        event["updateDescription"] = update_description
+
+    watcher.handle_change_event(event)
+
+    assert repository.calls == []
+
+
+def test_handle_change_event_processes_only_non_system_messages_in_mixed_conversation():
+    repository = StubRepository()
+
+    watcher = RealtimeConversationWatcher(
+        repository=repository,
+        openai_rater=lambda _text: [0, "hate"],
+        llama_guard_rater=lambda _text: "0",
+    )
+
+    event = {
+        "operationType": "insert",
+        "fullDocument": {
+            "_id": "conversation-mixed-roles",
+            "participant_id": "p1",
+            "model": "test-model",
+            "experiment_id": "exp-1",
+            "conversation_id": "conversation-mixed-roles",
+            "project_id": "2026_03_08",
+            "created_at": "2026-03-02T00:00:00Z",
+            "messages": [
+                _message("system prompt", [], role="system"),
+                _message("needs rating", [], role="user"),
             ],
             "opened_by": [],
             "reviewed_by": [],


### PR DESCRIPTION
## Summary
- exclude `system` role messages from automated reviewer moderation
- reuse the same eligibility gate in startup backfill and realtime change handling
- add repository and watcher coverage for system-only and mixed-role conversations

## Validation
- `poetry run pytest tests/test_database_repository.py tests/test_realtime_watcher.py`
- `poetry run pre-commit run --files hpms/database/repository.py hpms/monitoring/realtime_watcher.py tests/test_database_repository.py tests/test_realtime_watcher.py`