### PR TITLE
Align review state with messages

### DIFF
--- a/docs/adr/2026-03-02-ban-24-hpms-mongo-schema-alignment-and-realtime-monitoring.md
+++ b/docs/adr/2026-03-02-ban-24-hpms-mongo-schema-alignment-and-realtime-monitoring.md
@@ -28,23 +28,33 @@ HPMS and dashboard must share this schema:
 ```json
 {
   "_id": "ObjectId",
+  "conversation_id": "string",
   "participant_id": "string",
   "model": "string",
   "experiment_id": "string",
+  "project_id": "string",
   "created_at": "ISODate",
+  "custom_system_message_id": "string",
+  "multi_rounds": "boolean",
   "messages": [
     {
       "content": "string",
       "role": "string",
       "timestamp": "ISODate",
       "type": "string",
+      "flagged": "boolean",
+      "flagged_at": "ISODate",
+      "flagged_by": "string",
+      "flag_category": "string",
+      "flag_other_reason": "string",
       "user_flag": {
         "category": "string",
         "category_other": "string",
         "reviews": [
           {
             "reviewer_id": "string",
-            "approved": "bool",
+            "reviewer_username": "string",
+            "approved": "boolean",
             "comment": "string",
             "reviewed_at": "ISODate"
           }
@@ -53,9 +63,18 @@ HPMS and dashboard must share this schema:
       "reviewer_flags": [
         {
           "reviewer_id": "string",
+          "reviewer_by_username": "string",
           "created_at": "ISODate",
           "categories": ["string"],
-          "category_other": "string"
+          "category_other": "string",
+          "comment": "string"
+        }
+      ],
+      "duplicate_flags": [
+        {
+          "reviewer_id": "string",
+          "reviewer_username": "string",
+          "flagged_at": "ISODate"
         }
       ]
     }
@@ -66,17 +85,19 @@ HPMS and dashboard must share this schema:
       "opened_at": "ISODate"
     }
   ],
-  "reviewed_by": [
+  "assigned_messages": [
     {
       "reviewer_id": "string",
-      "reviewed_at": "ISODate"
+      "message_index": "number",
+      "reason": "random_sample | participant_flag | expert_escalation",
+      "assigned_at": "ISODate"
     }
   ],
-  "assigned_to": [
+  "reviewed_messages": [
     {
       "reviewer_id": "string",
-      "reason": "string",
-      "assigned_at": "ISODate"
+      "message_index": "number",
+      "reviewed_at": "ISODate"
     }
   ]
 }
@@ -85,88 +106,94 @@ HPMS and dashboard must share this schema:
 No additional schema fields are introduced.
 
 ## Monitoring Output Storage (Using Only Provided Fields)
-Because no dedicated monitoring field exists in the schema, monitoring results are stored in `messages[].reviewer_flags`.
+Because no dedicated monitoring field exists in the schema, monitoring results are
+stored in `messages[].reviewer_flags`.
 
 ### System reviewer IDs
 - OpenAI moderation result entry:
   - `reviewer_id = "system_openai_moderation"`
+  - `reviewer_by_username = "system_openai_moderation"`
 - Llama Guard result entry:
   - `reviewer_id = "system_llama_guard"`
+  - `reviewer_by_username = "system_llama_guard"`
 
 ### Stored values
 Each system result is one `reviewer_flags` element:
 - `reviewer_id`: system reviewer ID above.
+- `reviewer_by_username`: same value as the system reviewer ID.
 - `created_at`: rating timestamp.
 - `categories`:
-  - OpenAI: list of flagged category names from `_rate_text_with_openai_moderation` output.
-  - Llama Guard: empty list for safe (`"0"`) or single-item list with mapped category for unsafe.
+  - OpenAI: list of flagged category names from
+    `_rate_text_with_openai_moderation` output.
+  - Llama Guard: empty list for safe (`"0"`) or single-item list with mapped
+    category for unsafe.
 - `category_other`:
   - Empty string by default.
-  - If provider returns unexpected free-form output, store it in `category_other`.
+  - If provider returns unexpected free-form output, store it in
+    `category_other`.
+- `comment`:
+  - Empty string for automated writes.
 
 ### Idempotency rule
-Enforce one system entry per provider per message by upserting on `(conversation_id, message_index, reviewer_id)`.
+Enforce one system entry per provider per message by upserting on
+`(_id, message_index, reviewer_id)`.
 
 ## Decision: `MessageDocument` vs `ConversationMessage`
 Keep both.
 
-- Keep `ConversationMessage` in `hpms/loading/models.py` for offline/synthetic dataset processing.
-- Add `MessageDocument` (Mongo conversation message model) for dashboard-aligned database documents.
+- Keep `ConversationMessage` in `hpms/loading/models.py` for offline/synthetic
+  dataset processing.
+- Add `MessageDocument` (Mongo conversation message model) for
+  dashboard-aligned database documents.
 
 Reason:
 - They represent different domains and field sets.
 - `ConversationMessage` currently supports dataset generation/evaluation shape.
-- Mongo conversation messages need flag/review fields from the dashboard contract.
+- Mongo conversation messages need flag/review fields from the dashboard
+  contract.
 
 ## Architecture Changes
 
 ### 1) New database models
-Add a Mongo schema module, e.g.:
+Add a Mongo schema module:
 - `hpms/database/models.py`
 
 Models to add:
 - `UserFlagReviewDocument`
 - `UserFlagDocument`
 - `ReviewerFlagDocument`
+- `DuplicateFlagDocument`
 - `MessageDocument`
-- `ConversationReviewStateDocument` (for `opened_by` / `reviewed_by` elements)
-- `ConversationAssignmentDocument` (for `assigned_to` elements)
+- `OpenedByDocument`
+- `AssignedMessageDocument`
+- `ReviewedMessageDocument`
 - `ConversationDocument`
 
 These models must match the canonical schema above exactly.
 
-### 2) New Mongo repository layer
-Add:
-- `hpms/database/repository.py`
-
-Responsibilities:
-- Connect to MongoDB collection.
-- Fetch conversations/messages needing monitoring writes.
-- Upsert system reviewer flags for each provider.
-- Keep writes idempotent.
+### 2) Mongo repository layer
+`hpms/database/repository.py` is responsible for:
+- Connecting to MongoDB collection.
+- Fetching conversations/messages needing monitoring writes.
+- Upserting system reviewer flags for each provider.
+- Keeping writes idempotent using Mongo `_id`.
 
 ### 3) Realtime watcher service
-Add:
-- `hpms/monitoring/realtime_watcher.py`
-
-Responsibilities:
-- On startup: backfill messages missing either system reviewer entry.
-- Start MongoDB change stream on `Conversations` collection.
-- Reconnect with exponential backoff + jitter after change stream failures.
-- Process new message additions and message content updates.
-- Call both rating functions.
-- Persist results into `messages[].reviewer_flags`.
-- Log runtime counters for observability.
+`hpms/monitoring/realtime_watcher.py` is responsible for:
+- Backfilling messages missing either system reviewer entry on startup.
+- Watching the `Conversations` collection via MongoDB change streams.
+- Reconnecting with exponential backoff + jitter after change stream failures.
+- Processing new message additions and message content updates.
+- Calling both rating functions.
+- Persisting results into `messages[].reviewer_flags`.
+- Logging runtime counters for observability.
 
 ### 4) Runtime entrypoint
-Add script:
-- `hpms/monitoring/watch_mongo_conversations.py`
-
-Responsibilities:
-- Read env config.
-- Configure watcher log level from env.
-- Start watcher loop.
-- Handle graceful shutdown.
+`hpms/monitoring/watch_mongo_conversations.py` is responsible for:
+- Reading env config.
+- Configuring watcher log level from env.
+- Starting the watcher loop.
+- Handling graceful shutdown.
 
 ### 5) Configuration
 Add env vars to `env.example`:
@@ -185,12 +212,15 @@ Add env vars to `env.example`:
 ## Processing Rules
 
 ### Message selection
-A message requires processing if either of the following does not exist in `reviewer_flags`:
+A message requires processing if either of the following does not exist in
+`reviewer_flags`:
 - `reviewer_id = "system_openai_moderation"`
 - `reviewer_id = "system_llama_guard"`
 
-Validation tolerance:
-- if `messages[].user_flag` is missing, watcher defaults it to an empty object (`category=""`, `category_other=""`, `reviews=[]`) before processing.
+The schema is strict for fresh databases:
+- producers must populate `user_flag`, `reviewer_flags`, `duplicate_flags`,
+  `assigned_messages`, and `reviewed_messages`;
+- HPMS does not accept legacy field names or compatibility aliases.
 
 ### OpenAI normalization
 Input: list from `_rate_text_with_openai_moderation`.
@@ -202,18 +232,22 @@ Input: list from `_rate_text_with_openai_moderation`.
 ### Llama Guard normalization
 Input: string from `_rate_text_with_llama_guard`.
 - If output is `"0"`: `categories=[]`, `category_other=""`.
-- If output matches known unsafe category: `categories=[<category>]`, `category_other=""`.
+- If output matches known unsafe category: `categories=[<category>]`,
+  `category_other=""`.
 - Otherwise: `categories=[]`, `category_other=<raw output>`.
 
 ### Failure behavior
 - If one provider fails, still persist the other provider result.
-- During startup backfill, retry failed provider writes until success, retry budget exhaustion, or no retry-eligible targets remain.
-- After startup, retry failed provider on future change events and future restarts.
+- During startup backfill, retry failed provider writes until success, retry
+  budget exhaustion, or no retry-eligible targets remain.
+- After startup, retry failed provider on future change events and future
+  restarts.
 - Do not create duplicate system reviewer entries.
 
 ### Import behavior
 - `hpms.monitoring` exports `RealtimeConversationWatcher` lazily.
-- Importing non-watcher monitoring components must not require moderation credentials at module import time.
+- Importing non-watcher monitoring components must not require moderation
+  credentials at module import time.
 
 ## Testing Plan
 
@@ -222,6 +256,8 @@ Input: string from `_rate_text_with_llama_guard`.
 2. Llama Guard result normalization.
 3. Idempotent upsert behavior for system reviewer IDs.
 4. Message needs-processing detection logic.
+5. Strict rejection of legacy field names and invalid message-level assignment
+   state.
 
 ### Integration tests
 1. Startup backfill rates existing unrated messages.
@@ -230,17 +266,11 @@ Input: string from `_rate_text_with_llama_guard`.
 4. No duplicate `reviewer_flags` entries after repeated identical events.
 
 ## Acceptance Criteria
-1. HPMS writes and validates conversation documents using the exact schema above.
+1. HPMS writes and validates conversation documents using the exact schema
+   above.
 2. When a new message is added, both rating functions are executed.
-3. Each provider output is saved in the corresponding message under `reviewer_flags` using system reviewer IDs.
+3. Each provider output is saved in the corresponding message under
+   `reviewer_flags` using system reviewer IDs.
 4. No non-schema fields are written.
-5. `ConversationMessage` remains for dataset workflows; new Mongo-specific `MessageDocument` is used for DB workflows.
-
-## File-Level Change Plan
-- `pyproject.toml`: add Mongo client dependency.
-- `env.example`: add Mongo configuration vars.
-- `hpms/database/models.py`: add canonical Mongo document models.
-- `hpms/database/repository.py`: add DB read/write methods.
-- `hpms/monitoring/realtime_watcher.py`: add backfill + change stream processing.
-- `hpms/monitoring/watch_mongo_conversations.py`: add module entrypoint runner.
-- `tests/`: add watcher/repository normalization and idempotency tests.
+5. `ConversationMessage` remains for dataset workflows; new Mongo-specific
+   `MessageDocument` is used for DB workflows.

--- a/hpms/database/__init__.py
+++ b/hpms/database/__init__.py
@@ -1,11 +1,11 @@
 """Database package exports."""
 
 from hpms.database.models import (
-    ConversationAssignmentDocument,
+    AssignedMessageDocument,
     ConversationDocument,
     MessageDocument,
     OpenedByDocument,
-    ReviewedByDocument,
+    ReviewedMessageDocument,
     ReviewerFlagDocument,
     UserFlagDocument,
     UserFlagReviewDocument,
@@ -24,8 +24,8 @@ __all__ = [
     "UserFlagDocument",
     "ReviewerFlagDocument",
     "OpenedByDocument",
-    "ReviewedByDocument",
-    "ConversationAssignmentDocument",
+    "ReviewedMessageDocument",
+    "AssignedMessageDocument",
     "MessageBackfillTarget",
     "MongoConversationRepository",
     "SYSTEM_OPENAI_REVIEWER_ID",

--- a/hpms/database/models.py
+++ b/hpms/database/models.py
@@ -1,38 +1,20 @@
 """MongoDB document schemas for HPMS conversation data."""
 
 from datetime import datetime
-from typing import Any, List, Literal
+from typing import Literal
 
+from bson import ObjectId
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 # pylint: disable=too-few-public-methods
-class _BlankOptionalIdentityFieldMixin:
-    """Normalize blank optional identity fields to ``None``."""
-
-    @field_validator(
-        "reviewer_username",
-        "created_by",
-        "reviewer_by_username",
-        "flagged_by",
-        mode="before",
-        check_fields=False,
-    )
-    @classmethod
-    def blank_optional_identity_field_to_none(cls, value: Any) -> Any:
-        """Treat blank legacy identity strings as missing values."""
-        if value is None:
-            return None
-        if isinstance(value, str) and not value.strip():
-            return None
-        return value
-
-
-class _NonBlankRequiredIdentityFieldMixin:
+class _NonBlankRequiredFieldMixin:
     """Reject whitespace-only values for required identity fields."""
 
     @field_validator(
         "reviewer_id",
+        "reviewer_username",
+        "reviewer_by_username",
         "participant_id",
         "experiment_id",
         "conversation_id",
@@ -41,67 +23,73 @@ class _NonBlankRequiredIdentityFieldMixin:
         check_fields=False,
     )
     @classmethod
-    def reject_blank_required_identity_field(cls, value: Any) -> Any:
-        """Ensure required identity fields contain a non-whitespace value."""
+    def reject_blank_required_field(cls, value: object) -> object:
+        """Ensure required string fields contain a non-whitespace value."""
         if isinstance(value, str) and not value.strip():
             raise ValueError("Value must contain at least 1 non-whitespace character")
         return value
 
 
-class UserFlagReviewDocument(
-    _BlankOptionalIdentityFieldMixin, _NonBlankRequiredIdentityFieldMixin, BaseModel
-):
+class _NonBlankOptionalFieldMixin:
+    """Reject whitespace-only values for optional identity fields."""
+
+    @field_validator("flagged_by", mode="before", check_fields=False)
+    @classmethod
+    def reject_blank_optional_field(cls, value: object) -> object:
+        """Ensure optional identity strings are either missing or non-blank."""
+        if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
+            raise ValueError("Value must contain at least 1 non-whitespace character")
+        return value
+
+
+class UserFlagReviewDocument(_NonBlankRequiredFieldMixin, BaseModel):
     """Review of a participant flag by a human reviewer."""
 
     model_config = ConfigDict(extra="forbid")
 
     reviewer_id: str = Field(..., min_length=1)
-    reviewer_username: str | None = Field(default=None, min_length=1)
+    reviewer_username: str = Field(..., min_length=1)
     approved: bool
-    comment: str = ""
+    comment: str
     reviewed_at: datetime
 
 
-class UserFlagDocument(_BlankOptionalIdentityFieldMixin, BaseModel):
+class UserFlagDocument(BaseModel):
     """Participant-created flag on a single message."""
 
     model_config = ConfigDict(extra="forbid")
 
-    category: str = ""
-    category_other: str = ""
-    created_at: datetime | None = None
-    created_by: str | None = Field(default=None, min_length=1)
-    reviews: List[UserFlagReviewDocument] = Field(default_factory=list)
+    category: str
+    category_other: str
+    reviews: list[UserFlagReviewDocument]
 
 
-class ReviewerFlagDocument(
-    _BlankOptionalIdentityFieldMixin, _NonBlankRequiredIdentityFieldMixin, BaseModel
-):
+class ReviewerFlagDocument(_NonBlankRequiredFieldMixin, BaseModel):
     """Reviewer-created flag on a single message."""
 
     model_config = ConfigDict(extra="forbid")
 
     reviewer_id: str = Field(..., min_length=1)
-    reviewer_by_username: str | None = Field(default=None, min_length=1)
+    reviewer_by_username: str = Field(..., min_length=1)
     created_at: datetime
-    categories: List[str] = Field(default_factory=list)
-    category_other: str = ""
-    comment: str = ""
+    categories: list[str]
+    category_other: str
+    comment: str
 
 
-class DuplicateFlagDocument(
-    _BlankOptionalIdentityFieldMixin, _NonBlankRequiredIdentityFieldMixin, BaseModel
-):
+class DuplicateFlagDocument(_NonBlankRequiredFieldMixin, BaseModel):
     """Duplicate flag metadata for a single message."""
 
     model_config = ConfigDict(extra="forbid")
 
     reviewer_id: str = Field(..., min_length=1)
-    reviewer_username: str | None = Field(default=None, min_length=1)
+    reviewer_username: str = Field(..., min_length=1)
     flagged_at: datetime
 
 
-class MessageDocument(_BlankOptionalIdentityFieldMixin, BaseModel):
+class MessageDocument(_NonBlankOptionalFieldMixin, BaseModel):
     """Message document embedded in a conversation."""
 
     model_config = ConfigDict(extra="forbid")
@@ -110,17 +98,17 @@ class MessageDocument(_BlankOptionalIdentityFieldMixin, BaseModel):
     role: str = Field(..., min_length=1)
     timestamp: datetime
     type: str = Field(..., min_length=1)
-    flagged: bool | None = None
-    flagged_at: datetime | None = None
-    flagged_by: str | None = Field(default=None, min_length=1)
-    flag_category: str | None = None
-    flag_other_reason: str | None = None
-    user_flag: UserFlagDocument | None = None
-    reviewer_flags: List[ReviewerFlagDocument] = Field(default_factory=list)
-    duplicate_flags: List[DuplicateFlagDocument] = Field(default_factory=list)
+    flagged: bool
+    flagged_at: datetime | None
+    flagged_by: str | None
+    flag_category: str | None
+    flag_other_reason: str | None
+    user_flag: UserFlagDocument
+    reviewer_flags: list[ReviewerFlagDocument]
+    duplicate_flags: list[DuplicateFlagDocument]
 
 
-class OpenedByDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
+class OpenedByDocument(_NonBlankRequiredFieldMixin, BaseModel):
     """Reviewer open-state entry."""
 
     model_config = ConfigDict(extra="forbid")
@@ -129,63 +117,46 @@ class OpenedByDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     opened_at: datetime
 
 
-class ReviewedByDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
-    """Reviewer reviewed-state entry."""
+class ReviewedMessageDocument(_NonBlankRequiredFieldMixin, BaseModel):
+    """Reviewer reviewed-state entry for a specific message."""
 
     model_config = ConfigDict(extra="forbid")
 
     reviewer_id: str = Field(..., min_length=1)
+    message_index: int = Field(..., ge=0)
     reviewed_at: datetime
 
 
-class ConversationAssignmentDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
-    """Assignment metadata for a reviewer and conversation."""
+class AssignedMessageDocument(_NonBlankRequiredFieldMixin, BaseModel):
+    """Assignment metadata for a reviewer and message."""
 
     model_config = ConfigDict(extra="forbid")
 
     reviewer_id: str = Field(..., min_length=1)
-    reason: str = Field(..., min_length=1)
+    message_index: int = Field(..., ge=0)
+    reason: Literal["random_sample", "participant_flag", "expert_escalation"]
     assigned_at: datetime
 
 
-class NaturalnessRatingDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
-    """Naturalness rating metadata for a conversation."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    reviewer_id: str = Field(..., min_length=1)
-    coherence: int = Field(..., ge=1, le=5)
-    topic_progression: int = Field(..., ge=1, le=5)
-    rated_at: datetime
-
-
-class RealismRatingDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
-    """Realism rating metadata for a conversation."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    reviewer_id: str = Field(..., min_length=1)
-    rating: Literal[0, 5, 10]
-    rated_at: datetime
-
-
-class ConversationDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
+class ConversationDocument(_NonBlankRequiredFieldMixin, BaseModel):
     """MongoDB conversation document matching the dashboard schema."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
-    id: Any = Field(..., alias="_id")
+    id: ObjectId = Field(..., alias="_id")
+    conversation_id: str = Field(..., min_length=1)
     participant_id: str = Field(..., min_length=1)
     model: str = Field(..., min_length=1)
     experiment_id: str = Field(..., min_length=1)
-    conversation_id: str = Field(..., min_length=1)
     project_id: str = Field(..., min_length=1)
     created_at: datetime
-    custom_system_message_id: str | None = None
-    multi_rounds: bool = True
-    messages: List[MessageDocument] = Field(...)
-    opened_by: List[OpenedByDocument] = Field(default_factory=list)
-    reviewed_by: List[ReviewedByDocument] = Field(default_factory=list)
-    assigned_to: List[ConversationAssignmentDocument] = Field(default_factory=list)
-    naturalness_ratings: List[NaturalnessRatingDocument] = Field(default_factory=list)
-    realism_ratings: List[RealismRatingDocument] = Field(default_factory=list)
+    custom_system_message_id: str | None
+    multi_rounds: bool
+    messages: list[MessageDocument]
+    opened_by: list[OpenedByDocument]
+    assigned_messages: list[AssignedMessageDocument]
+    reviewed_messages: list[ReviewedMessageDocument]

--- a/hpms/database/repository.py
+++ b/hpms/database/repository.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 class MessageBackfillTarget:
     """Message that still requires one or more system moderation writes."""
 
-    conversation_id: Any
+    document_id: Any
     message_index: int
     content: str
     missing_reviewer_ids: Set[str]
@@ -133,10 +133,12 @@ class MongoConversationRepository:
                 "conversation_id": 1,
                 "project_id": 1,
                 "created_at": 1,
+                "custom_system_message_id": 1,
+                "multi_rounds": 1,
                 "messages": 1,
                 "opened_by": 1,
-                "reviewed_by": 1,
-                "assigned_to": 1,
+                "reviewed_messages": 1,
+                "assigned_messages": 1,
             },
         )
 
@@ -147,7 +149,7 @@ class MongoConversationRepository:
             if validated_conversation is None:
                 continue
 
-            conversation_id = validated_conversation.get("_id")
+            document_id = validated_conversation.get("_id")
             messages = validated_conversation.get("messages", [])
             if not isinstance(messages, list):
                 continue
@@ -163,7 +165,7 @@ class MongoConversationRepository:
                 missing = {
                     reviewer_id
                     for reviewer_id in missing
-                    if (conversation_id, message_index, reviewer_id)
+                    if (document_id, message_index, reviewer_id)
                     not in excluded_provider_keys
                 }
                 if not missing:
@@ -171,7 +173,7 @@ class MongoConversationRepository:
 
                 targets.append(
                     MessageBackfillTarget(
-                        conversation_id=conversation_id,
+                        document_id=document_id,
                         message_index=message_index,
                         content=content,
                         missing_reviewer_ids=missing,
@@ -183,11 +185,11 @@ class MongoConversationRepository:
         return targets
 
     def get_message(
-        self, conversation_id: Any, message_index: int
+        self, document_id: Any, message_index: int
     ) -> Optional[dict[str, Any]]:
         """Fetch a single message from a conversation document by index."""
         conversation = self.collection.find_one(
-            {"_id": conversation_id},
+            {"_id": document_id},
             projection={"messages": 1},
         )
         if not conversation:
@@ -208,8 +210,8 @@ class MongoConversationRepository:
             validated_message = MessageDocument.model_validate(message)
         except ValidationError as error:
             LOGGER.warning(
-                "Skipping invalid message document conversation=%s index=%s: %s",
-                conversation_id,
+                "Skipping invalid message document document_id=%s index=%s: %s",
+                document_id,
                 message_index,
                 error,
             )
@@ -220,7 +222,7 @@ class MongoConversationRepository:
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def upsert_system_reviewer_flag(
         self,
-        conversation_id: Any,
+        document_id: Any,
         message_index: int,
         reviewer_id: str,
         categories: Iterable[str],
@@ -233,14 +235,16 @@ class MongoConversationRepository:
 
         reviewer_flag = {
             "reviewer_id": reviewer_id,
+            "reviewer_by_username": reviewer_id,
             "created_at": timestamp,
             "categories": normalized_categories,
             "category_other": category_other,
+            "comment": "",
         }
 
         self.collection.update_one(
             {
-                "_id": conversation_id,
+                "_id": document_id,
                 f"messages.{message_index}": {"$exists": True},
             },
             self._build_reviewer_flag_pipeline(

--- a/hpms/monitoring/realtime_watcher.py
+++ b/hpms/monitoring/realtime_watcher.py
@@ -223,7 +223,7 @@ class RealtimeConversationWatcher:
             for target in targets:
                 eligible_reviewer_ids: set[str] = set()
                 for reviewer_id in target.missing_reviewer_ids:
-                    key = (target.conversation_id, target.message_index, reviewer_id)
+                    key = (target.document_id, target.message_index, reviewer_id)
                     if attempts.get(key, 0) >= self.backfill_max_retries:
                         unresolved_provider_keys.add(key)
                         continue
@@ -233,14 +233,14 @@ class RealtimeConversationWatcher:
                     continue
 
                 eligible_target = MessageBackfillTarget(
-                    conversation_id=target.conversation_id,
+                    document_id=target.document_id,
                     message_index=target.message_index,
                     content=target.content,
                     missing_reviewer_ids=eligible_reviewer_ids,
                 )
                 provider_results = self.process_message_target(eligible_target)
                 for reviewer_id in eligible_reviewer_ids:
-                    key = (target.conversation_id, target.message_index, reviewer_id)
+                    key = (target.document_id, target.message_index, reviewer_id)
                     if provider_results.get(reviewer_id, False):
                         attempts.pop(key, None)
                         unresolved_provider_keys.discard(key)
@@ -256,8 +256,8 @@ class RealtimeConversationWatcher:
                     unresolved_provider_keys.add(key)
                     LOGGER.error(
                         "Startup backfill retries exhausted for "
-                        "conversation=%s message_index=%s reviewer_id=%s attempts=%d",
-                        target.conversation_id,
+                        "document_id=%s message_index=%s reviewer_id=%s attempts=%d",
+                        target.document_id,
                         target.message_index,
                         reviewer_id,
                         attempt_count,
@@ -321,7 +321,7 @@ class RealtimeConversationWatcher:
                 continue
 
             target = MessageBackfillTarget(
-                conversation_id=validated_document.get("_id"),
+                document_id=validated_document.get("_id"),
                 message_index=message_index,
                 content=content,
                 missing_reviewer_ids=missing_reviewer_ids,
@@ -402,7 +402,7 @@ class RealtimeConversationWatcher:
             raw_result = rater(target.content)
             categories, category_other = normalizer(raw_result)
             self.repository.upsert_system_reviewer_flag(
-                conversation_id=target.conversation_id,
+                document_id=target.document_id,
                 message_index=target.message_index,
                 reviewer_id=reviewer_id,
                 categories=categories,
@@ -415,9 +415,9 @@ class RealtimeConversationWatcher:
             # pragma: no cover - network/runtime path
             self._provider_failure_counts[reviewer_id] += 1
             LOGGER.exception(
-                "Failed %s rating for conversation=%s message_index=%s",
+                "Failed %s rating for document_id=%s message_index=%s",
                 provider_name,
-                target.conversation_id,
+                target.document_id,
                 target.message_index,
             )
             return False

--- a/tests/integration/test_monitoring_mongo_integration.py
+++ b/tests/integration/test_monitoring_mongo_integration.py
@@ -9,6 +9,7 @@ import os
 from typing import Any
 import uuid
 
+from bson import ObjectId
 import pytest
 
 from hpms.database.repository import (
@@ -42,30 +43,38 @@ def _conversation_doc(
 ) -> dict[str, object]:
     now = datetime.now(timezone.utc)
     return {
-        "_id": conversation_id,
+        "_id": ObjectId(),
+        "conversation_id": conversation_id,
         "participant_id": "p1",
         "model": "test-model",
         "experiment_id": "exp-1",
-        "conversation_id": conversation_id,
         "project_id": "2026_03_08",
         "created_at": now,
+        "custom_system_message_id": None,
+        "multi_rounds": True,
         "messages": [
             {
                 "content": "needs moderation",
                 "role": "assistant",
                 "timestamp": now,
                 "type": "assistant",
+                "flagged": False,
+                "flagged_at": None,
+                "flagged_by": None,
+                "flag_category": None,
+                "flag_other_reason": None,
                 "user_flag": {
                     "category": "",
                     "category_other": "",
                     "reviews": [],
                 },
                 "reviewer_flags": reviewer_flags or [],
+                "duplicate_flags": [],
             }
         ],
         "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
+        "assigned_messages": [],
+        "reviewed_messages": [],
     }
 
 
@@ -83,7 +92,8 @@ def collection():
 
 
 def test_startup_backfill_writes_both_system_flags(collection):
-    collection.insert_one(_conversation_doc("conversation-int-1"))
+    document = _conversation_doc("conversation-int-1")
+    collection.insert_one(document)
     repository = MongoConversationRepository.from_collection(collection)
     watcher = RealtimeConversationWatcher(
         repository=repository,
@@ -94,7 +104,7 @@ def test_startup_backfill_writes_both_system_flags(collection):
 
     watcher.run_startup_backfill()
 
-    stored = collection.find_one({"_id": "conversation-int-1"})
+    stored = collection.find_one({"_id": document["_id"]})
     assert stored is not None
     reviewer_ids = {
         flag["reviewer_id"] for flag in stored["messages"][0]["reviewer_flags"]
@@ -104,13 +114,20 @@ def test_startup_backfill_writes_both_system_flags(collection):
 
 def test_change_event_writes_missing_system_flag(collection):
     now = datetime.now(timezone.utc)
-    openai_flag = {
-        "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
-        "created_at": now,
-        "categories": ["hate"],
-        "category_other": "",
-    }
-    collection.insert_one(_conversation_doc("conversation-int-2", [openai_flag]))
+    document = _conversation_doc(
+        "conversation-int-2",
+        [
+            {
+                "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
+                "reviewer_by_username": SYSTEM_OPENAI_REVIEWER_ID,
+                "created_at": now,
+                "categories": ["hate"],
+                "category_other": "",
+                "comment": "",
+            }
+        ],
+    )
+    collection.insert_one(document)
 
     repository = MongoConversationRepository.from_collection(collection)
     watcher = RealtimeConversationWatcher(
@@ -119,12 +136,12 @@ def test_change_event_writes_missing_system_flag(collection):
         llama_guard_rater=lambda _text: "Hate",
     )
 
-    full_document = collection.find_one({"_id": "conversation-int-2"})
+    full_document = collection.find_one({"_id": document["_id"]})
     assert full_document is not None
     event: dict[str, Any] = {"operationType": "insert", "fullDocument": full_document}
     watcher.handle_change_event(event)
 
-    stored = collection.find_one({"_id": "conversation-int-2"})
+    stored = collection.find_one({"_id": document["_id"]})
     assert stored is not None
     reviewer_ids = {
         flag["reviewer_id"] for flag in stored["messages"][0]["reviewer_flags"]
@@ -133,7 +150,8 @@ def test_change_event_writes_missing_system_flag(collection):
 
 
 def test_change_event_does_not_create_duplicate_provider_entries(collection):
-    collection.insert_one(_conversation_doc("conversation-int-3"))
+    document = _conversation_doc("conversation-int-3")
+    collection.insert_one(document)
 
     repository = MongoConversationRepository.from_collection(collection)
     watcher = RealtimeConversationWatcher(
@@ -142,14 +160,14 @@ def test_change_event_does_not_create_duplicate_provider_entries(collection):
         llama_guard_rater=lambda _text: "Hate",
     )
 
-    stale_document = collection.find_one({"_id": "conversation-int-3"})
+    stale_document = collection.find_one({"_id": document["_id"]})
     assert stale_document is not None
     event = {"operationType": "insert", "fullDocument": stale_document}
 
     watcher.handle_change_event(event)
     watcher.handle_change_event(event)
 
-    stored = collection.find_one({"_id": "conversation-int-3"})
+    stored = collection.find_one({"_id": document["_id"]})
     assert stored is not None
     reviewer_flags = stored["messages"][0]["reviewer_flags"]
     assert len(reviewer_flags) == 2

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -1,6 +1,6 @@
 """Tests for Mongo conversation repository helpers."""
 
-# pylint: disable=missing-function-docstring,too-few-public-methods,too-many-locals,duplicate-code
+# pylint: disable=missing-function-docstring,too-few-public-methods,duplicate-code
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from bson import ObjectId
 import pytest
 from pydantic import ValidationError
 
@@ -42,6 +43,7 @@ class FakeCollection:
             return None
         return deepcopy(doc)
 
+    # pylint: disable=too-many-locals
     def update_one(
         self,
         query: dict[str, Any],
@@ -70,7 +72,7 @@ class FakeCollection:
             return _UpdateResult(0)
 
         message = doc["messages"][message_index]
-        reviewer_flags = message.setdefault("reviewer_flags", [])
+        reviewer_flags = message["reviewer_flags"]
 
         if isinstance(update, list):
             assert len(update) == 1
@@ -90,58 +92,73 @@ class FakeCollection:
         raise AssertionError("Unsupported update operation in fake collection")
 
 
+def _message_doc(
+    now: datetime,
+    *,
+    content: str,
+    role: str = "assistant",
+    reviewer_flags: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "content": content,
+        "role": role,
+        "timestamp": now,
+        "type": role,
+        "flagged": False,
+        "flagged_at": None,
+        "flagged_by": None,
+        "flag_category": None,
+        "flag_other_reason": None,
+        "user_flag": {
+            "category": "",
+            "category_other": "",
+            "reviews": [],
+        },
+        "reviewer_flags": reviewer_flags or [],
+        "duplicate_flags": [],
+    }
+
+
 def _conversation_doc() -> dict[str, Any]:
     now = datetime.now(timezone.utc)
+    document_id = ObjectId()
     return {
-        "_id": "conversation-1",
+        "_id": document_id,
+        "conversation_id": "conversation-1",
         "participant_id": "p1",
         "model": "test-model",
         "experiment_id": "exp-1",
-        "conversation_id": "conversation-1",
         "project_id": "2026_03_08",
         "created_at": now,
+        "custom_system_message_id": None,
+        "multi_rounds": True,
         "messages": [
-            {
-                "content": "message one",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "user_flag": {
-                    "category": "",
-                    "category_other": "",
-                    "reviews": [],
-                },
-                "reviewer_flags": [],
-            },
-            {
-                "content": "message two",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "user_flag": {
-                    "category": "",
-                    "category_other": "",
-                    "reviews": [],
-                },
-                "reviewer_flags": [
+            _message_doc(now, content="message one"),
+            _message_doc(
+                now,
+                content="message two",
+                reviewer_flags=[
                     {
                         "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
+                        "reviewer_by_username": SYSTEM_OPENAI_REVIEWER_ID,
                         "created_at": now,
                         "categories": ["violence"],
                         "category_other": "",
+                        "comment": "",
                     }
                 ],
-            },
+            ),
         ],
         "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
+        "assigned_messages": [],
+        "reviewed_messages": [],
     }
 
 
 def test_get_backfill_targets_includes_only_messages_missing_system_flags():
+    conversation = _conversation_doc()
     repository = MongoConversationRepository.from_collection(
-        FakeCollection([_conversation_doc()])
+        FakeCollection([conversation])
     )
 
     targets = repository.get_backfill_targets(batch_size=10)
@@ -149,7 +166,7 @@ def test_get_backfill_targets_includes_only_messages_missing_system_flags():
     assert len(targets) == 2
 
     first = targets[0]
-    assert first.conversation_id == "conversation-1"
+    assert first.document_id == conversation["_id"]
     assert first.message_index == 0
     assert first.missing_reviewer_ids == {
         SYSTEM_OPENAI_REVIEWER_ID,
@@ -157,17 +174,19 @@ def test_get_backfill_targets_includes_only_messages_missing_system_flags():
     }
 
     second = targets[1]
+    assert second.document_id == conversation["_id"]
     assert second.message_index == 1
     assert second.missing_reviewer_ids == {SYSTEM_LLAMA_REVIEWER_ID}
 
 
 def test_get_backfill_targets_excludes_exhausted_provider_keys():
+    conversation = _conversation_doc()
     repository = MongoConversationRepository.from_collection(
-        FakeCollection([_conversation_doc()])
+        FakeCollection([conversation])
     )
     excluded_provider_keys = {
-        ("conversation-1", 0, SYSTEM_OPENAI_REVIEWER_ID),
-        ("conversation-1", 0, SYSTEM_LLAMA_REVIEWER_ID),
+        (conversation["_id"], 0, SYSTEM_OPENAI_REVIEWER_ID),
+        (conversation["_id"], 0, SYSTEM_LLAMA_REVIEWER_ID),
     }
 
     targets = repository.get_backfill_targets(
@@ -175,293 +194,98 @@ def test_get_backfill_targets_excludes_exhausted_provider_keys():
     )
 
     assert len(targets) == 1
-    assert targets[0].conversation_id == "conversation-1"
+    assert targets[0].document_id == conversation["_id"]
     assert targets[0].message_index == 1
     assert targets[0].missing_reviewer_ids == {SYSTEM_LLAMA_REVIEWER_ID}
 
 
 def test_missing_system_reviewers_returns_empty_for_system_role_message():
-    message = _conversation_doc()["messages"][0]
-    message["role"] = "system"
+    now = datetime.now(timezone.utc)
+    message = _message_doc(now, content="system prompt", role="system")
 
     missing = MongoConversationRepository.missing_system_reviewers(message)
 
     assert missing == set()
 
 
-def test_get_backfill_targets_skips_system_role_messages():
-    conversation = _conversation_doc()
-    conversation["messages"][0]["role"] = "system"
-    conversation["messages"][1]["role"] = "user"
-    conversation["messages"][1]["reviewer_flags"] = []
-
-    repository = MongoConversationRepository.from_collection(
-        FakeCollection([conversation])
-    )
-
-    targets = repository.get_backfill_targets(batch_size=10)
-
-    assert len(targets) == 1
-    assert targets[0].message_index == 1
-    assert targets[0].missing_reviewer_ids == {
-        SYSTEM_OPENAI_REVIEWER_ID,
-        SYSTEM_LLAMA_REVIEWER_ID,
-    }
-
-
 def test_upsert_system_reviewer_flag_is_idempotent_per_message_and_provider():
-    collection = FakeCollection([_conversation_doc()])
+    conversation = _conversation_doc()
+    collection = FakeCollection([conversation])
     repository = MongoConversationRepository.from_collection(collection)
 
     repository.upsert_system_reviewer_flag(
-        conversation_id="conversation-1",
+        document_id=conversation["_id"],
         message_index=0,
         reviewer_id=SYSTEM_OPENAI_REVIEWER_ID,
         categories=["harassment"],
         category_other="",
-        created_at=datetime(2026, 3, 2, 12, 0, 0),
+        created_at=datetime(2026, 3, 2, 12, 0, 0, tzinfo=timezone.utc),
     )
     repository.upsert_system_reviewer_flag(
-        conversation_id="conversation-1",
+        document_id=conversation["_id"],
         message_index=0,
         reviewer_id=SYSTEM_OPENAI_REVIEWER_ID,
         categories=["hate"],
         category_other="",
-        created_at=datetime(2026, 3, 2, 12, 1, 0),
+        created_at=datetime(2026, 3, 2, 12, 1, 0, tzinfo=timezone.utc),
     )
 
-    message_flags = collection.docs["conversation-1"]["messages"][0]["reviewer_flags"]
+    message_flags = collection.docs[conversation["_id"]]["messages"][0][
+        "reviewer_flags"
+    ]
     assert len(message_flags) == 1
     assert message_flags[0]["reviewer_id"] == SYSTEM_OPENAI_REVIEWER_ID
+    assert message_flags[0]["reviewer_by_username"] == SYSTEM_OPENAI_REVIEWER_ID
     assert message_flags[0]["categories"] == ["hate"]
+    assert message_flags[0]["comment"] == ""
     assert collection.update_calls == 2
-
-
-def test_upsert_system_reviewer_flag_pipeline_updates_messages_array():
-    collection = FakeCollection([_conversation_doc()])
-    repository = MongoConversationRepository.from_collection(collection)
-
-    repository.upsert_system_reviewer_flag(
-        conversation_id="conversation-1",
-        message_index=0,
-        reviewer_id=SYSTEM_LLAMA_REVIEWER_ID,
-        categories=[],
-        category_other="",
-        created_at=datetime(2026, 3, 2, 12, 0, 0),
-    )
-
-    updated_doc = collection.docs["conversation-1"]
-    assert isinstance(updated_doc["messages"], list)
-    assert isinstance(updated_doc["messages"][0], dict)
-    assert "0" not in updated_doc["messages"][0]
 
 
 def test_get_backfill_targets_skips_invalid_conversations():
     invalid = {
-        "_id": "invalid",
-        # Missing required top-level schema fields
+        "_id": ObjectId(),
         "messages": [],
     }
+    valid = _conversation_doc()
 
     repository = MongoConversationRepository.from_collection(
-        FakeCollection([invalid, _conversation_doc()])
+        FakeCollection([invalid, valid])
     )
 
     targets = repository.get_backfill_targets(batch_size=10)
 
     assert len(targets) == 2
-    assert all(target.conversation_id == "conversation-1" for target in targets)
+    assert all(target.document_id == valid["_id"] for target in targets)
 
 
-def test_get_backfill_targets_defaults_missing_user_flag():
+def test_conversation_document_accepts_canonical_shape():
     now = datetime.now(timezone.utc)
-    conversation_missing_user_flag = {
-        "_id": "conversation-missing-user-flag",
-        "participant_id": "p2",
-        "model": "test-model",
-        "experiment_id": "exp-2",
-        "conversation_id": "conversation-missing-user-flag",
-        "project_id": "2026_03_08",
-        "created_at": now,
-        "messages": [
-            {
-                "content": "message without user flag",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "reviewer_flags": [],
-            }
-        ],
-        "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
-    }
-
-    repository = MongoConversationRepository.from_collection(
-        FakeCollection([conversation_missing_user_flag])
-    )
-
-    targets = repository.get_backfill_targets(batch_size=10)
-
-    assert len(targets) == 1
-    assert targets[0].conversation_id == "conversation-missing-user-flag"
-    assert targets[0].message_index == 0
-    assert targets[0].missing_reviewer_ids == {
-        SYSTEM_OPENAI_REVIEWER_ID,
-        SYSTEM_LLAMA_REVIEWER_ID,
-    }
-
-
-def test_get_backfill_targets_defaults_missing_optional_lists():
-    now = datetime.now(timezone.utc)
-    conversation_missing_optional_lists = {
-        "_id": "conversation-missing-lists",
-        "participant_id": "p3",
-        "model": "test-model",
-        "experiment_id": "exp-3",
-        "conversation_id": "conversation-missing-lists",
-        "project_id": "2026_03_08",
-        "created_at": now,
-        "messages": [
-            {
-                "content": "message without optional lists",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-            }
-        ],
-    }
-
-    repository = MongoConversationRepository.from_collection(
-        FakeCollection([conversation_missing_optional_lists])
-    )
-
-    targets = repository.get_backfill_targets(batch_size=10)
-
-    assert len(targets) == 1
-    assert targets[0].conversation_id == "conversation-missing-lists"
-    assert targets[0].message_index == 0
-    assert targets[0].missing_reviewer_ids == {
-        SYSTEM_OPENAI_REVIEWER_ID,
-        SYSTEM_LLAMA_REVIEWER_ID,
-    }
-
-
-def test_get_backfill_targets_accepts_simple_chat_fields():
-    now = datetime.now(timezone.utc)
-    legacy_conversation = {
-        "_id": "conversation-legacy-fields",
-        "participant_id": "p4",
-        "model": "test-model",
-        "experiment_id": "exp-4",
-        "created_at": now,
-        "conversation_id": "conversation-legacy-fields",
-        "project_id": "2026_03_08",
-        "custom_system_message_id": None,
-        "multi_rounds": True,
-        "messages": [
-            {
-                "content": "message with legacy flag metadata",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "flagged": None,
-                "flagged_at": None,
-                "flagged_by": None,
-                "flag_category": None,
-                "flag_other_reason": None,
-                "user_flag": None,
-                "reviewer_flags": [],
-                "duplicate_flags": [],
-            }
-        ],
-        "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
-    }
-
-    repository = MongoConversationRepository.from_collection(
-        FakeCollection([legacy_conversation])
-    )
-
-    targets = repository.get_backfill_targets(batch_size=10)
-
-    assert len(targets) == 1
-    assert targets[0].conversation_id == "conversation-legacy-fields"
-    assert targets[0].message_index == 0
-    assert targets[0].missing_reviewer_ids == {
-        SYSTEM_OPENAI_REVIEWER_ID,
-        SYSTEM_LLAMA_REVIEWER_ID,
-    }
-
-
-def test_get_backfill_targets_accepts_blank_optional_reviewer_identity_fields():
-    now = datetime.now(timezone.utc)
-    conversation = {
-        "_id": "conversation-blank-reviewer-username",
-        "participant_id": "p5",
-        "model": "test-model",
-        "experiment_id": "exp-5",
-        "conversation_id": "conversation-blank-reviewer-username",
-        "project_id": "2026_03_09",
-        "created_at": now,
-        "messages": [
-            {
-                "content": "message with legacy reviewer username",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "reviewer_flags": [
-                    {
-                        "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
-                        "reviewer_by_username": "",
-                        "created_at": now,
-                        "categories": ["violence"],
-                        "category_other": "",
-                        "comment": "",
-                    }
-                ],
-            }
-        ],
-        "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
-    }
-
-    repository = MongoConversationRepository.from_collection(
-        FakeCollection([conversation])
-    )
-
-    targets = repository.get_backfill_targets(batch_size=10)
-
-    assert len(targets) == 1
-    assert targets[0].conversation_id == "conversation-blank-reviewer-username"
-    assert targets[0].message_index == 0
-    assert targets[0].missing_reviewer_ids == {SYSTEM_LLAMA_REVIEWER_ID}
-
-
-def test_conversation_document_accepts_canonical_extended_fields():
-    now = datetime.now(timezone.utc)
+    document_id = ObjectId()
     document = ConversationDocument.model_validate(
         {
-            "_id": "conversation-canonical",
+            "_id": document_id,
+            "conversation_id": "conversation-canonical",
             "participant_id": "p5",
             "model": "test-model",
             "experiment_id": "exp-5",
-            "conversation_id": "conversation-canonical",
             "project_id": "2026_03_08",
             "created_at": now,
+            "custom_system_message_id": None,
+            "multi_rounds": True,
             "messages": [
                 {
                     "content": "message with all fields",
                     "role": "assistant",
                     "timestamp": now,
                     "type": "assistant",
+                    "flagged": True,
+                    "flagged_at": now,
+                    "flagged_by": "participant-1",
+                    "flag_category": "harassment",
+                    "flag_other_reason": None,
                     "user_flag": {
                         "category": "harassment",
                         "category_other": "",
-                        "created_at": now,
-                        "created_by": "participant",
                         "reviews": [
                             {
                                 "reviewer_id": "reviewer-1",
@@ -491,211 +315,104 @@ def test_conversation_document_accepts_canonical_extended_fields():
                     ],
                 }
             ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-            "naturalness_ratings": [
+            "opened_by": [
                 {
                     "reviewer_id": "reviewer-4",
-                    "coherence": 5,
-                    "topic_progression": 4,
-                    "rated_at": now,
+                    "opened_at": now,
                 }
             ],
-            "realism_ratings": [
+            "assigned_messages": [
                 {
                     "reviewer_id": "reviewer-5",
-                    "rating": 10,
-                    "rated_at": now,
+                    "message_index": 0,
+                    "reason": "participant_flag",
+                    "assigned_at": now,
+                }
+            ],
+            "reviewed_messages": [
+                {
+                    "reviewer_id": "reviewer-6",
+                    "message_index": 0,
+                    "reviewed_at": now,
                 }
             ],
         }
     )
 
+    assert document.id == document_id
     assert document.messages[0].user_flag.reviews[0].reviewer_username == "alice"
     assert document.messages[0].reviewer_flags[0].reviewer_by_username == "bob"
-    assert document.messages[0].reviewer_flags[0].comment == "Escalate"
     assert document.messages[0].duplicate_flags[0].reviewer_username == "carol"
-    assert document.naturalness_ratings[0].coherence == 5
-    assert document.realism_ratings[0].rating == 10
-
-
-def test_conversation_document_normalizes_blank_optional_identity_fields():
-    now = datetime.now(timezone.utc)
-    document = ConversationDocument.model_validate(
-        {
-            "_id": "conversation-blank-optional-fields",
-            "participant_id": "p7",
-            "model": "test-model",
-            "experiment_id": "exp-7",
-            "conversation_id": "conversation-blank-optional-fields",
-            "project_id": "2026_03_09",
-            "created_at": now,
-            "messages": [
-                {
-                    "content": "message with blank optional identity fields",
-                    "role": "assistant",
-                    "timestamp": now,
-                    "type": "assistant",
-                    "flagged_by": "   ",
-                    "user_flag": {
-                        "category": "harassment",
-                        "category_other": "",
-                        "created_by": "",
-                        "reviews": [
-                            {
-                                "reviewer_id": "reviewer-1",
-                                "reviewer_username": " ",
-                                "approved": True,
-                                "comment": "",
-                                "reviewed_at": now,
-                            }
-                        ],
-                    },
-                    "reviewer_flags": [
-                        {
-                            "reviewer_id": "reviewer-2",
-                            "reviewer_by_username": "",
-                            "created_at": now,
-                            "categories": [],
-                            "category_other": "",
-                            "comment": "",
-                        }
-                    ],
-                    "duplicate_flags": [
-                        {
-                            "reviewer_id": "reviewer-3",
-                            "reviewer_username": "   ",
-                            "flagged_at": now,
-                        }
-                    ],
-                }
-            ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        }
-    )
-
-    assert document.messages[0].flagged_by is None
-    assert document.messages[0].user_flag.created_by is None
-    assert document.messages[0].user_flag.reviews[0].reviewer_username is None
-    assert document.messages[0].reviewer_flags[0].reviewer_by_username is None
-    assert document.messages[0].duplicate_flags[0].reviewer_username is None
-
-
-def test_conversation_document_accepts_simple_chat_compatible_shape():
-    now = datetime.now(timezone.utc)
-    document = ConversationDocument.model_validate(
-        {
-            "_id": "conversation-simple-chat",
-            "participant_id": "p6",
-            "model": "gpt-4o",
-            "experiment_id": "exp-6",
-            "conversation_id": "conversation-simple-chat",
-            "project_id": "2026_03_09",
-            "created_at": now,
-            "custom_system_message_id": None,
-            "multi_rounds": True,
-            "messages": [
-                {
-                    "content": "You're alright",
-                    "role": "system",
-                    "timestamp": now,
-                    "type": "text",
-                    "flagged": None,
-                    "flagged_at": None,
-                    "flagged_by": None,
-                    "flag_category": None,
-                    "flag_other_reason": None,
-                    "user_flag": None,
-                    "reviewer_flags": [],
-                    "duplicate_flags": [],
-                }
-            ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        }
-    )
-
-    assert document.custom_system_message_id is None
-    assert document.multi_rounds is True
-    assert document.messages[0].flagged is None
-    assert document.messages[0].user_flag is None
-    assert document.messages[0].duplicate_flags == []
+    assert document.assigned_messages[0].reason == "participant_flag"
+    assert document.reviewed_messages[0].message_index == 0
 
 
 @pytest.mark.parametrize(
-    "mutator",
+    ("mutator", "match"),
     [
-        lambda document: document.update({"unexpected_top_level": "nope"}),
-        lambda document: document["messages"][0]["user_flag"].update(
-            {"unexpected_user_flag": "nope"}
+        (
+            lambda document: document.update({"reviewed_by": []}),
+            "reviewed_by",
         ),
-        lambda document: document["messages"][0]["reviewer_flags"][0].update(
-            {"unexpected_reviewer_flag": "nope"}
+        (
+            lambda document: document.update({"assigned_to": []}),
+            "assigned_to",
         ),
-        lambda document: document["naturalness_ratings"][0].update(
-            {"unexpected_rating_field": "nope"}
+        (
+            lambda document: document.update({"naturalness_ratings": []}),
+            "naturalness_ratings",
         ),
-    ],
-    ids=[
-        "unknown top-level field",
-        "unknown user_flag field",
-        "unknown reviewer_flags field",
-        "unknown naturalness_ratings field",
+        (
+            lambda document: document.update({"realism_ratings": []}),
+            "realism_ratings",
+        ),
+        (
+            lambda document: document["messages"][0]["user_flag"].update(
+                {"created_at": datetime.now(timezone.utc)}
+            ),
+            "created_at",
+        ),
+        (
+            lambda document: document["messages"][0]["user_flag"].update(
+                {"created_by": "participant"}
+            ),
+            "created_by",
+        ),
     ],
 )
-def test_conversation_document_rejects_unknown_fields(mutator):
+def test_conversation_document_rejects_legacy_fields(mutator, match):
     now = datetime.now(timezone.utc)
-    document = {
-        "_id": "conversation-strict",
-        "participant_id": "p6",
-        "model": "test-model",
-        "experiment_id": "exp-6",
-        "conversation_id": "conversation-strict",
-        "project_id": "2026_03_08",
-        "created_at": now,
-        "messages": [
-            {
-                "content": "message",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "user_flag": {
-                    "category": "",
-                    "category_other": "",
-                    "reviews": [],
-                },
-                "reviewer_flags": [
-                    {
-                        "reviewer_id": "reviewer-1",
-                        "created_at": now,
-                        "categories": [],
-                        "category_other": "",
-                        "comment": "",
-                    }
-                ],
-            }
-        ],
-        "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
-        "naturalness_ratings": [
-            {
-                "reviewer_id": "reviewer-2",
-                "coherence": 3,
-                "topic_progression": 4,
-                "rated_at": now,
-            }
-        ],
-        "realism_ratings": [],
-    }
+    document = _conversation_doc()
+    document["messages"] = [_message_doc(now, content="strict message")]
 
     mutator(document)
 
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError, match=match):
+        ConversationDocument.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "user_flag",
+        "reviewer_flags",
+        "duplicate_flags",
+    ],
+)
+def test_conversation_document_requires_message_review_fields(missing_field):
+    document = _conversation_doc()
+    del document["messages"][0][missing_field]
+
+    with pytest.raises(ValidationError, match=missing_field):
+        ConversationDocument.model_validate(document)
+
+
+@pytest.mark.parametrize("missing_field", ["assigned_messages", "reviewed_messages"])
+def test_conversation_document_requires_top_level_message_state_lists(missing_field):
+    document = _conversation_doc()
+    del document[missing_field]
+
+    with pytest.raises(ValidationError, match=missing_field):
         ConversationDocument.model_validate(document)
 
 
@@ -703,51 +420,128 @@ def test_conversation_document_rejects_unknown_fields(mutator):
     ("mutator", "match"),
     [
         (
-            lambda document: document.update({"participant_id": ""}),
-            "participant_id",
+            lambda document: document["assigned_messages"][0].update(
+                {"message_index": -1}
+            ),
+            "message_index",
         ),
         (
-            lambda document: document["messages"][0]["reviewer_flags"][0].update(
-                {"reviewer_id": " "}
+            lambda document: document["reviewed_messages"][0].update(
+                {"message_index": -1}
             ),
-            "reviewer_id",
+            "message_index",
+        ),
+        (
+            lambda document: document["assigned_messages"][0].update(
+                {"reason": "legacy_reason"}
+            ),
+            "reason",
         ),
     ],
-    ids=["blank participant_id", "blank reviewer_id"],
 )
-def test_conversation_document_rejects_blank_required_identity_fields(mutator, match):
+def test_conversation_document_rejects_invalid_message_level_review_state(
+    mutator, match
+):
     now = datetime.now(timezone.utc)
-    document = {
-        "_id": "conversation-required-identities",
-        "participant_id": "p8",
-        "model": "test-model",
-        "experiment_id": "exp-8",
-        "conversation_id": "conversation-required-identities",
-        "project_id": "2026_03_09",
-        "created_at": now,
-        "messages": [
-            {
-                "content": "message",
-                "role": "assistant",
-                "timestamp": now,
-                "type": "assistant",
-                "reviewer_flags": [
-                    {
-                        "reviewer_id": "reviewer-1",
-                        "created_at": now,
-                        "categories": [],
-                        "category_other": "",
-                        "comment": "",
-                    }
-                ],
-            }
-        ],
-        "opened_by": [],
-        "reviewed_by": [],
-        "assigned_to": [],
-    }
+    document = _conversation_doc()
+    document["assigned_messages"] = [
+        {
+            "reviewer_id": "reviewer-1",
+            "message_index": 0,
+            "reason": "random_sample",
+            "assigned_at": now,
+        }
+    ]
+    document["reviewed_messages"] = [
+        {
+            "reviewer_id": "reviewer-2",
+            "message_index": 0,
+            "reviewed_at": now,
+        }
+    ]
 
     mutator(document)
 
     with pytest.raises(ValidationError, match=match):
+        ConversationDocument.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (
+            lambda document: document.update({"participant_id": " "}),
+            "participant_id",
+        ),
+        (
+            lambda document: document["messages"][0]["user_flag"]["reviews"][0].update(
+                {"reviewer_username": " "}
+            ),
+            "reviewer_username",
+        ),
+        (
+            lambda document: document["messages"][0]["reviewer_flags"][0].update(
+                {"reviewer_by_username": " "}
+            ),
+            "reviewer_by_username",
+        ),
+        (
+            lambda document: document["messages"][0].update({"flagged_by": " "}),
+            "flagged_by",
+        ),
+    ],
+)
+def test_conversation_document_rejects_blank_identity_fields(mutator, match):
+    now = datetime.now(timezone.utc)
+    document = _conversation_doc()
+    document["messages"] = [
+        {
+            **_message_doc(now, content="message"),
+            "flagged": True,
+            "flagged_at": now,
+            "flagged_by": "participant-1",
+            "user_flag": {
+                "category": "harassment",
+                "category_other": "",
+                "reviews": [
+                    {
+                        "reviewer_id": "reviewer-1",
+                        "reviewer_username": "alice",
+                        "approved": True,
+                        "comment": "",
+                        "reviewed_at": now,
+                    }
+                ],
+            },
+            "reviewer_flags": [
+                {
+                    "reviewer_id": "reviewer-2",
+                    "reviewer_by_username": "bob",
+                    "created_at": now,
+                    "categories": [],
+                    "category_other": "",
+                    "comment": "",
+                }
+            ],
+            "duplicate_flags": [
+                {
+                    "reviewer_id": "reviewer-3",
+                    "reviewer_username": "carol",
+                    "flagged_at": now,
+                }
+            ],
+        }
+    ]
+
+    mutator(document)
+
+    with pytest.raises(ValidationError, match=match):
+        ConversationDocument.model_validate(document)
+
+
+def test_conversation_document_requires_object_id():
+    document = _conversation_doc()
+    document["_id"] = "conversation-1"
+
+    with pytest.raises(ValidationError, match="_id"):
         ConversationDocument.model_validate(document)

--- a/tests/test_realtime_watcher.py
+++ b/tests/test_realtime_watcher.py
@@ -1,6 +1,9 @@
 """Tests for realtime watcher normalization and event handling."""
 
-# pylint: disable=missing-function-docstring,missing-class-docstring,too-many-arguments,too-many-positional-arguments,use-implicit-booleaness-not-comparison,duplicate-code
+# pylint: disable=missing-function-docstring,missing-class-docstring
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+# pylint: disable=use-implicit-booleaness-not-comparison,duplicate-code
+# pylint: disable=protected-access
 
 from __future__ import annotations
 
@@ -10,10 +13,11 @@ from datetime import datetime
 import os
 import subprocess
 import sys
-from types import SimpleNamespace
-from typing import Any, Iterable, cast
+from typing import Any, Iterable
 
+from bson import ObjectId
 import pytest
+from pydantic import ValidationError
 
 from hpms.database.models import ConversationDocument
 from hpms.database.repository import (
@@ -31,7 +35,7 @@ from hpms.monitoring.realtime_watcher import (
 
 @dataclass
 class _Call:
-    conversation_id: Any
+    document_id: Any
     message_index: int
     reviewer_id: str
     categories: list[str]
@@ -55,9 +59,12 @@ class StubRepository(MongoConversationRepository):
 
     @staticmethod
     def validate_conversation_document(conversation: dict[str, Any]):
-        return ConversationDocument.model_validate(conversation).model_dump(
-            by_alias=True
-        )
+        try:
+            return ConversationDocument.model_validate(conversation).model_dump(
+                by_alias=True
+            )
+        except ValidationError:
+            return None
 
     def get_backfill_targets(
         self,
@@ -72,7 +79,7 @@ class StubRepository(MongoConversationRepository):
 
     def upsert_system_reviewer_flag(
         self,
-        conversation_id: Any,
+        document_id: Any,
         message_index: int,
         reviewer_id: str,
         categories: Iterable[str],
@@ -82,7 +89,7 @@ class StubRepository(MongoConversationRepository):
         _ = created_at
         self.calls.append(
             _Call(
-                conversation_id=conversation_id,
+                document_id=document_id,
                 message_index=message_index,
                 reviewer_id=reviewer_id,
                 categories=list(categories),
@@ -110,7 +117,7 @@ class FilteringStubRepository(StubRepository):
                 reviewer_id
                 for reviewer_id in target.missing_reviewer_ids
                 if (
-                    target.conversation_id,
+                    target.document_id,
                     target.message_index,
                     reviewer_id,
                 )
@@ -121,7 +128,7 @@ class FilteringStubRepository(StubRepository):
 
             eligible_targets.append(
                 MessageBackfillTarget(
-                    conversation_id=target.conversation_id,
+                    document_id=target.document_id,
                     message_index=target.message_index,
                     content=target.content,
                     missing_reviewer_ids=remaining_reviewer_ids,
@@ -134,7 +141,7 @@ class FilteringStubRepository(StubRepository):
 
     def upsert_system_reviewer_flag(
         self,
-        conversation_id: Any,
+        document_id: Any,
         message_index: int,
         reviewer_id: str,
         categories: Iterable[str],
@@ -142,7 +149,7 @@ class FilteringStubRepository(StubRepository):
         created_at: datetime | None = None,
     ) -> None:
         super().upsert_system_reviewer_flag(
-            conversation_id=conversation_id,
+            document_id=document_id,
             message_index=message_index,
             reviewer_id=reviewer_id,
             categories=categories,
@@ -153,7 +160,7 @@ class FilteringStubRepository(StubRepository):
         updated_targets: list[MessageBackfillTarget] = []
         for target in self.targets:
             if (
-                target.conversation_id != conversation_id
+                target.document_id != document_id
                 or target.message_index != message_index
             ):
                 updated_targets.append(target)
@@ -164,7 +171,7 @@ class FilteringStubRepository(StubRepository):
             if remaining_reviewer_ids:
                 updated_targets.append(
                     MessageBackfillTarget(
-                        conversation_id=target.conversation_id,
+                        document_id=target.document_id,
                         message_index=target.message_index,
                         content=target.content,
                         missing_reviewer_ids=remaining_reviewer_ids,
@@ -172,6 +179,29 @@ class FilteringStubRepository(StubRepository):
                 )
 
         self.targets = updated_targets
+
+
+class FlakyWatchRepository(StubRepository):
+    """Repository whose change stream fails once, then reconnects."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls_count = 0
+        self.events: list[str] = []
+
+    def watch(self, max_await_time_ms: int = 1000):
+        _ = max_await_time_ms
+        self.calls_count += 1
+
+        @contextmanager
+        def stream_context():
+            if self.calls_count == 1:
+                raise RuntimeError("stream down")
+            self.events.append("watch-opened")
+            yield iter(())
+            raise KeyboardInterrupt()
+
+        return stream_context()
 
 
 def _message(
@@ -184,13 +214,41 @@ def _message(
         "content": content,
         "role": role,
         "timestamp": "2026-03-02T00:00:00Z",
-        "type": "assistant",
+        "type": role,
+        "flagged": False,
+        "flagged_at": None,
+        "flagged_by": None,
+        "flag_category": None,
+        "flag_other_reason": None,
         "user_flag": {
             "category": "",
             "category_other": "",
             "reviews": [],
         },
         "reviewer_flags": reviewer_flags,
+        "duplicate_flags": [],
+    }
+
+
+def _conversation_document(
+    document_id: ObjectId,
+    conversation_id: str,
+    messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "_id": document_id,
+        "conversation_id": conversation_id,
+        "participant_id": "p1",
+        "model": "test-model",
+        "experiment_id": "exp-1",
+        "project_id": "2026_03_08",
+        "created_at": "2026-03-02T00:00:00Z",
+        "custom_system_message_id": None,
+        "multi_rounds": True,
+        "messages": messages,
+        "opened_by": [],
+        "assigned_messages": [],
+        "reviewed_messages": [],
     }
 
 
@@ -246,8 +304,9 @@ def test_process_message_target_persists_both_provider_flags_when_missing():
         llama_guard_rater=lambda _text: "Hate",
     )
 
+    document_id = ObjectId()
     target = MessageBackfillTarget(
-        conversation_id="conversation-1",
+        document_id=document_id,
         message_index=2,
         content="test",
         missing_reviewer_ids={
@@ -262,6 +321,7 @@ def test_process_message_target_persists_both_provider_flags_when_missing():
 
     by_reviewer_id = {call.reviewer_id: call for call in repository.calls}
 
+    assert by_reviewer_id[SYSTEM_OPENAI_REVIEWER_ID].document_id == document_id
     assert by_reviewer_id[SYSTEM_OPENAI_REVIEWER_ID].categories == ["violence"]
     assert by_reviewer_id[SYSTEM_OPENAI_REVIEWER_ID].category_other == ""
 
@@ -278,45 +338,43 @@ def test_handle_change_event_only_processes_messages_missing_system_flags():
         llama_guard_rater=lambda _text: "0",
     )
 
+    document_id = ObjectId()
     event = {
         "operationType": "insert",
-        "fullDocument": {
-            "_id": "conversation-2",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-2",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "messages": [
+        "fullDocument": _conversation_document(
+            document_id,
+            "conversation-2",
+            [
                 _message(
                     "already rated",
                     [
                         {
                             "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
+                            "reviewer_by_username": SYSTEM_OPENAI_REVIEWER_ID,
                             "created_at": "2026-03-02T00:00:00Z",
                             "categories": [],
                             "category_other": "",
+                            "comment": "",
                         },
                         {
                             "reviewer_id": SYSTEM_LLAMA_REVIEWER_ID,
+                            "reviewer_by_username": SYSTEM_LLAMA_REVIEWER_ID,
                             "created_at": "2026-03-02T00:00:00Z",
                             "categories": [],
                             "category_other": "",
+                            "comment": "",
                         },
                     ],
                 ),
                 _message("needs rating", []),
             ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        },
+        ),
     }
 
     watcher.handle_change_event(event)
 
     assert len(repository.calls) == 2
+    assert all(call.document_id == document_id for call in repository.calls)
     assert all(call.message_index == 1 for call in repository.calls)
 
 
@@ -344,21 +402,14 @@ def test_handle_change_event_skips_system_role_messages(
         llama_guard_rater=lambda _text: "0",
     )
 
+    document_id = ObjectId()
     event: dict[str, Any] = {
         "operationType": operation_type,
-        "fullDocument": {
-            "_id": "conversation-system-only",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-system-only",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "messages": [_message("system prompt", [], role="system")],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        },
+        "fullDocument": _conversation_document(
+            document_id,
+            "conversation-system-only",
+            [_message("system prompt", [], role="system")],
+        ),
     }
     if update_description is not None:
         event["updateDescription"] = update_description
@@ -377,33 +428,27 @@ def test_handle_change_event_processes_only_non_system_messages_in_mixed_convers
         llama_guard_rater=lambda _text: "0",
     )
 
+    document_id = ObjectId()
     event = {
         "operationType": "insert",
-        "fullDocument": {
-            "_id": "conversation-mixed-roles",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-mixed-roles",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "messages": [
+        "fullDocument": _conversation_document(
+            document_id,
+            "conversation-mixed-roles",
+            [
                 _message("system prompt", [], role="system"),
                 _message("needs rating", [], role="user"),
             ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        },
+        ),
     }
 
     watcher.handle_change_event(event)
 
     assert len(repository.calls) == 2
+    assert all(call.document_id == document_id for call in repository.calls)
     assert all(call.message_index == 1 for call in repository.calls)
 
 
-def test_handle_change_event_defaults_missing_user_flag_and_processes_message():
+def test_handle_change_event_skips_invalid_document_from_change_stream():
     repository = StubRepository()
 
     watcher = RealtimeConversationWatcher(
@@ -412,177 +457,23 @@ def test_handle_change_event_defaults_missing_user_flag_and_processes_message():
         llama_guard_rater=lambda _text: "0",
     )
 
-    event = {
-        "operationType": "insert",
-        "fullDocument": {
-            "_id": "conversation-2b",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-2b",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "messages": [
-                {
-                    "content": "needs rating",
-                    "role": "assistant",
-                    "timestamp": "2026-03-02T00:00:00Z",
-                    "type": "assistant",
-                    "reviewer_flags": [],
-                }
-            ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        },
-    }
-
-    watcher.handle_change_event(event)
-
-    assert len(repository.calls) == 2
-    assert all(call.message_index == 0 for call in repository.calls)
-
-
-def test_handle_change_event_accepts_blank_optional_reviewer_identity_fields():
-    repository = StubRepository()
-
-    watcher = RealtimeConversationWatcher(
-        repository=repository,
-        openai_rater=lambda _text: [0, "hate"],
-        llama_guard_rater=lambda _text: "0",
+    document = _conversation_document(
+        ObjectId(), "conversation-invalid", [_message("x", [])]
     )
+    del document["assigned_messages"]
 
-    event = {
-        "operationType": "insert",
-        "fullDocument": {
-            "_id": "conversation-blank-reviewer-username",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-blank-reviewer-username",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "messages": [
-                _message(
-                    "needs one remaining rating",
-                    [
-                        {
-                            "reviewer_id": SYSTEM_OPENAI_REVIEWER_ID,
-                            "reviewer_by_username": "",
-                            "created_at": "2026-03-02T00:00:00Z",
-                            "categories": [],
-                            "category_other": "",
-                        }
-                    ],
-                )
-            ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        },
-    }
+    watcher.handle_change_event({"operationType": "insert", "fullDocument": document})
 
-    watcher.handle_change_event(event)
-
-    assert len(repository.calls) == 1
-    assert repository.calls[0].message_index == 0
-    assert repository.calls[0].reviewer_id == SYSTEM_LLAMA_REVIEWER_ID
-
-
-def test_handle_change_event_defaults_missing_optional_message_and_conversation_lists():
-    repository = StubRepository()
-
-    watcher = RealtimeConversationWatcher(
-        repository=repository,
-        openai_rater=lambda _text: [0, "hate"],
-        llama_guard_rater=lambda _text: "0",
-    )
-
-    event = {
-        "operationType": "insert",
-        "fullDocument": {
-            "_id": "conversation-2c",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-2c",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "messages": [
-                {
-                    "content": "needs rating",
-                    "role": "assistant",
-                    "timestamp": "2026-03-02T00:00:00Z",
-                    "type": "assistant",
-                }
-            ],
-        },
-    }
-
-    watcher.handle_change_event(event)
-
-    assert len(repository.calls) == 2
-    assert all(call.message_index == 0 for call in repository.calls)
-
-
-def test_handle_change_event_accepts_simple_chat_fields():
-    repository = StubRepository()
-
-    watcher = RealtimeConversationWatcher(
-        repository=repository,
-        openai_rater=lambda _text: [0, "hate"],
-        llama_guard_rater=lambda _text: "0",
-    )
-
-    event = {
-        "operationType": "insert",
-        "fullDocument": {
-            "_id": "conversation-legacy",
-            "participant_id": "p1",
-            "model": "test-model",
-            "experiment_id": "exp-1",
-            "conversation_id": "conversation-legacy",
-            "project_id": "2026_03_08",
-            "created_at": "2026-03-02T00:00:00Z",
-            "custom_system_message_id": None,
-            "multi_rounds": True,
-            "messages": [
-                {
-                    "content": "needs rating",
-                    "role": "assistant",
-                    "timestamp": "2026-03-02T00:00:00Z",
-                    "type": "assistant",
-                    "flagged": None,
-                    "flagged_at": None,
-                    "flagged_by": None,
-                    "flag_category": None,
-                    "flag_other_reason": None,
-                    "user_flag": None,
-                    "reviewer_flags": [],
-                    "duplicate_flags": [],
-                }
-            ],
-            "opened_by": [],
-            "reviewed_by": [],
-            "assigned_to": [],
-        },
-    }
-
-    watcher.handle_change_event(event)
-
-    assert len(repository.calls) == 2
-    assert all(
-        call.conversation_id == "conversation-legacy" for call in repository.calls
-    )
-    assert all(call.message_index == 0 for call in repository.calls)
+    assert repository.calls == []
 
 
 def test_run_startup_backfill_processes_targets_until_empty():
+    document_id = ObjectId()
     repository = StubRepository(
         backfill_batches=[
             [
                 MessageBackfillTarget(
-                    conversation_id="conversation-3",
+                    document_id=document_id,
                     message_index=0,
                     content="one",
                     missing_reviewer_ids={
@@ -619,11 +510,12 @@ def test_run_startup_backfill_retries_transient_provider_failure():
             raise RuntimeError("temporary failure")
         return [0, "hate"]
 
+    document_id = ObjectId()
     repository = StubRepository(
         backfill_batches=[
             [
                 MessageBackfillTarget(
-                    conversation_id="conversation-3b",
+                    document_id=document_id,
                     message_index=0,
                     content="one",
                     missing_reviewer_ids={
@@ -634,7 +526,7 @@ def test_run_startup_backfill_retries_transient_provider_failure():
             ],
             [
                 MessageBackfillTarget(
-                    conversation_id="conversation-3b",
+                    document_id=document_id,
                     message_index=0,
                     content="one",
                     missing_reviewer_ids={SYSTEM_OPENAI_REVIEWER_ID},
@@ -673,8 +565,9 @@ def test_run_startup_backfill_stops_after_retry_budget_exhausted():
     def always_failing_openai(_text: str):
         raise RuntimeError("always fail")
 
+    document_id = ObjectId()
     target = MessageBackfillTarget(
-        conversation_id="conversation-3c",
+        document_id=document_id,
         message_index=0,
         content="one",
         missing_reviewer_ids={SYSTEM_OPENAI_REVIEWER_ID},
@@ -683,7 +576,7 @@ def test_run_startup_backfill_stops_after_retry_budget_exhausted():
         backfill_batches=[
             [target],
             [target],
-            [target],  # this should remain unused after retry exhaustion
+            [target],
         ]
     )
 
@@ -704,6 +597,7 @@ def test_run_startup_backfill_stops_after_retry_budget_exhausted():
 
 def test_run_startup_backfill_skips_exhausted_keys_while_progress_continues():
     openai_calls = {"count": 0}
+    failing_document_id = ObjectId()
 
     def always_failing_openai(_text: str):
         openai_calls["count"] += 1
@@ -713,13 +607,13 @@ def test_run_startup_backfill_skips_exhausted_keys_while_progress_continues():
         backfill_batches=[
             [
                 MessageBackfillTarget(
-                    conversation_id="conversation-fail",
+                    document_id=failing_document_id,
                     message_index=0,
                     content="fail",
                     missing_reviewer_ids={SYSTEM_OPENAI_REVIEWER_ID},
                 ),
                 MessageBackfillTarget(
-                    conversation_id="conversation-ok-1",
+                    document_id=ObjectId(),
                     message_index=0,
                     content="ok",
                     missing_reviewer_ids={SYSTEM_LLAMA_REVIEWER_ID},
@@ -727,13 +621,13 @@ def test_run_startup_backfill_skips_exhausted_keys_while_progress_continues():
             ],
             [
                 MessageBackfillTarget(
-                    conversation_id="conversation-fail",
+                    document_id=failing_document_id,
                     message_index=0,
                     content="fail",
                     missing_reviewer_ids={SYSTEM_OPENAI_REVIEWER_ID},
                 ),
                 MessageBackfillTarget(
-                    conversation_id="conversation-ok-2",
+                    document_id=ObjectId(),
                     message_index=0,
                     content="ok",
                     missing_reviewer_ids={SYSTEM_LLAMA_REVIEWER_ID},
@@ -741,13 +635,13 @@ def test_run_startup_backfill_skips_exhausted_keys_while_progress_continues():
             ],
             [
                 MessageBackfillTarget(
-                    conversation_id="conversation-fail",
+                    document_id=failing_document_id,
                     message_index=0,
                     content="fail",
                     missing_reviewer_ids={SYSTEM_OPENAI_REVIEWER_ID},
                 ),
                 MessageBackfillTarget(
-                    conversation_id="conversation-ok-3",
+                    document_id=ObjectId(),
                     message_index=0,
                     content="ok",
                     missing_reviewer_ids={SYSTEM_LLAMA_REVIEWER_ID},
@@ -784,16 +678,18 @@ def test_run_startup_backfill_batch_size_one_processes_later_targets_after_exhau
         openai_calls["count"] += 1
         raise RuntimeError("always fail")
 
+    fail_document_id = ObjectId()
+    ok_document_id = ObjectId()
     repository = FilteringStubRepository(
         targets=[
             MessageBackfillTarget(
-                conversation_id="conversation-fail",
+                document_id=fail_document_id,
                 message_index=0,
                 content="fail",
                 missing_reviewer_ids={SYSTEM_OPENAI_REVIEWER_ID},
             ),
             MessageBackfillTarget(
-                conversation_id="conversation-ok",
+                document_id=ok_document_id,
                 message_index=1,
                 content="ok",
                 missing_reviewer_ids={SYSTEM_LLAMA_REVIEWER_ID},
@@ -815,7 +711,7 @@ def test_run_startup_backfill_batch_size_one_processes_later_targets_after_exhau
     assert openai_calls["count"] == 1
     assert watcher._unresolved_backfill_targets == 1  # pylint: disable=protected-access
     assert any(
-        call.conversation_id == "conversation-ok"
+        call.document_id == ok_document_id
         and call.reviewer_id == SYSTEM_LLAMA_REVIEWER_ID
         for call in repository.calls
     )
@@ -837,8 +733,9 @@ def test_failure_is_retried_on_later_attempt():
         llama_guard_rater=lambda _text: "0",
     )
 
+    document_id = ObjectId()
     target = MessageBackfillTarget(
-        conversation_id="conversation-4",
+        document_id=document_id,
         message_index=1,
         content="retry me",
         missing_reviewer_ids={
@@ -850,20 +747,20 @@ def test_failure_is_retried_on_later_attempt():
     watcher.process_message_target(target)
     watcher.process_message_target(target)
 
-    # OpenAI fails once and succeeds on retry; Llama Guard succeeds both times.
-    openai_calls = [
+    openai_writes = [
         call
         for call in repository.calls
         if call.reviewer_id == SYSTEM_OPENAI_REVIEWER_ID
     ]
-    llama_calls = [
+    llama_writes = [
         call
         for call in repository.calls
         if call.reviewer_id == SYSTEM_LLAMA_REVIEWER_ID
     ]
-    assert len(openai_calls) == 1
-    assert openai_calls[0].categories == ["violence"]
-    assert len(llama_calls) == 2
+    assert len(openai_writes) == 1
+    assert openai_writes[0].document_id == document_id
+    assert openai_writes[0].categories == ["violence"]
+    assert len(llama_writes) == 2
 
 
 def test_compute_reconnect_sleep_seconds_grows_and_caps(monkeypatch):
@@ -918,53 +815,32 @@ def test_monitoring_package_import_does_not_require_moderation_credentials():
     )
     result = subprocess.run(
         [sys.executable, "-c", command],
+        check=False,
         capture_output=True,
         text=True,
         env=env,
-        check=False,
     )
 
-    assert result.returncode == 0
-    assert "ok" in result.stdout
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
 
 
-def test_run_opens_change_stream_before_startup_backfill(monkeypatch):
-    event_order: list[str] = []
-
-    def _stream_iter():
-        yield {"operationType": "insert", "fullDocument": {}}
-        raise KeyboardInterrupt()
-
-    @contextmanager
-    def _watch_context():
-        event_order.append("watch_enter")
-        yield _stream_iter()
-
-    def _watch(max_await_time_ms):
-        _ = max_await_time_ms
-        event_order.append("watch_called")
-        return _watch_context()
-
+def test_run_reconnects_after_stream_failure(monkeypatch):
+    sleeps: list[float] = []
+    repository = FlakyWatchRepository()
     watcher = RealtimeConversationWatcher(
-        repository=cast(Any, SimpleNamespace(watch=_watch)),
+        repository=repository,
         openai_rater=lambda _text: [0],
         llama_guard_rater=lambda _text: "0",
+        reconnect_backoff_base_seconds=1.0,
+        reconnect_backoff_max_seconds=1.0,
+        reconnect_backoff_jitter_seconds=0.0,
     )
 
-    monkeypatch.setattr(
-        watcher,
-        "run_startup_backfill",
-        lambda: event_order.append("backfill_called"),
-    )
-    monkeypatch.setattr(
-        watcher,
-        "handle_change_event",
-        lambda _change_event: event_order.append("event_handled"),
-    )
+    monkeypatch.setattr("hpms.monitoring.realtime_watcher.time.sleep", sleeps.append)
 
     with pytest.raises(KeyboardInterrupt):
         watcher.run()
 
-    assert event_order.index("watch_called") < event_order.index("backfill_called")
-    assert event_order.index("watch_enter") < event_order.index("backfill_called")
-    assert event_order.index("backfill_called") < event_order.index("event_handled")
+    assert sleeps == [1.0]
+    assert repository.events == ["watch-opened"]


### PR DESCRIPTION
## Summary
- align the Mongo conversation schema with message-level review and assignment state
- validate Mongo `_id` as `ObjectId` and use `document_id` for watcher and repository writes
- update the schema ADR and strict repository/watcher test fixtures to the canonical contract

## Testing
- `poetry run pytest tests/test_database_repository.py tests/test_realtime_watcher.py tests/integration/test_monitoring_mongo_integration.py` (`44 passed, 3 skipped`; integration tests skipped without `HPMS_INTEGRATION_MONGODB_URI`)
- `poetry run pre-commit run --files hpms/database/models.py hpms/database/repository.py hpms/database/__init__.py hpms/monitoring/realtime_watcher.py tests/test_database_repository.py tests/test_realtime_watcher.py tests/integration/test_monitoring_mongo_integration.py docs/adr/2026-03-02-ban-24-hpms-mongo-schema-alignment-and-realtime-monitoring.md`