### PR TITLE
BAN-273: Add Compose watch support

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,12 @@ services:
     env_file:
       - .env
     restart: unless-stopped
+    develop:
+      watch:
+        - action: rebuild
+          path: hpms
+        - action: rebuild
+          path: Dockerfile
     healthcheck:
       test:
         [

--- a/script/start
+++ b/script/start
@@ -13,3 +13,4 @@ check_command docker
 
 fancy_echo "Starting local monitoring stack"
 docker compose --file compose.yml up --detach --remove-orphans
+docker compose --file compose.yml watch --no-up


### PR DESCRIPTION
## Summary
- add Docker Compose watch entries for the monitoring service
- start `docker compose watch --no-up` from `script/start`

## Validation
- `poetry run pre-commit run --files compose.yml script/start`
- `docker compose --file compose.yml config`

## Ticket
- BAN-273