### PR TITLE
Add MessageAssignmentDocument and ReviewedMessageDocument (BAN-299)

### DIFF
--- a/hpms/database/models.py
+++ b/hpms/database/models.py
@@ -148,6 +148,27 @@ class ConversationAssignmentDocument(_NonBlankRequiredIdentityFieldMixin, BaseMo
     assigned_at: datetime
 
 
+class MessageAssignmentDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
+    """Assignment metadata for a reviewer and a specific message index."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reviewer_id: str = Field(..., min_length=1)
+    message_index: int
+    reason: str = Field(..., min_length=1)
+    assigned_at: datetime
+
+
+class ReviewedMessageDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
+    """Reviewed-state entry for a specific message index."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reviewer_id: str = Field(..., min_length=1)
+    message_index: int
+    reviewed_at: datetime
+
+
 class NaturalnessRatingDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     """Naturalness rating metadata for a conversation."""
 
@@ -187,5 +208,7 @@ class ConversationDocument(_NonBlankRequiredIdentityFieldMixin, BaseModel):
     opened_by: List[OpenedByDocument] = Field(default_factory=list)
     reviewed_by: List[ReviewedByDocument] = Field(default_factory=list)
     assigned_to: List[ConversationAssignmentDocument] = Field(default_factory=list)
+    assigned_messages: List[MessageAssignmentDocument] = Field(default_factory=list)
+    reviewed_messages: List[ReviewedMessageDocument] = Field(default_factory=list)
     naturalness_ratings: List[NaturalnessRatingDocument] = Field(default_factory=list)
     realism_ratings: List[RealismRatingDocument] = Field(default_factory=list)

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -520,6 +520,52 @@ def test_conversation_document_accepts_canonical_extended_fields():
     assert document.realism_ratings[0].rating == 10
 
 
+def test_conversation_document_accepts_assigned_and_reviewed_messages():
+    now = datetime.now(timezone.utc)
+    document = ConversationDocument.model_validate(
+        {
+            "_id": "conversation-message-level-assignments",
+            "participant_id": "p6",
+            "model": "test-model",
+            "experiment_id": "exp-6",
+            "conversation_id": "conversation-message-level-assignments",
+            "project_id": "2026_03_08",
+            "created_at": now,
+            "messages": [
+                {
+                    "content": "hello",
+                    "role": "user",
+                    "timestamp": now,
+                    "type": "text",
+                }
+            ],
+            "assigned_messages": [
+                {
+                    "reviewer_id": "reviewer-1",
+                    "message_index": 0,
+                    "reason": "random_sample",
+                    "assigned_at": now,
+                }
+            ],
+            "reviewed_messages": [
+                {
+                    "reviewer_id": "reviewer-1",
+                    "message_index": 0,
+                    "reviewed_at": now,
+                }
+            ],
+        }
+    )
+
+    assert len(document.assigned_messages) == 1
+    assert document.assigned_messages[0].reviewer_id == "reviewer-1"
+    assert document.assigned_messages[0].message_index == 0
+    assert document.assigned_messages[0].reason == "random_sample"
+    assert len(document.reviewed_messages) == 1
+    assert document.reviewed_messages[0].reviewer_id == "reviewer-1"
+    assert document.reviewed_messages[0].message_index == 0
+
+
 def test_conversation_document_normalizes_blank_optional_identity_fields():
     now = datetime.now(timezone.utc)
     document = ConversationDocument.model_validate(


### PR DESCRIPTION
## Summary
- `assigned_messages[]` and `reviewed_messages[]` are written to MongoDB by the dashboard but were missing from `ConversationDocument`, causing Pydantic `extra_forbidden` validation errors that silently skipped every new conversation in the monitoring watcher
- Added `MessageAssignmentDocument` (`reviewer_id`, `message_index`, `reason`, `assigned_at`) for message-level assignments
- Added `ReviewedMessageDocument` (`reviewer_id`, `message_index`, `reviewed_at`) for message-level reviewed state
- Both new fields added to `ConversationDocument` with `default_factory=list` so older documents without them still validate

## Test plan
- [x] New unit test `test_conversation_document_accepts_assigned_and_reviewed_messages` validates both fields parse correctly
- [ ] Deploy updated container and confirm no more `Skipping invalid conversation document` warnings in `hpms-monitoring-watcher-1` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)