### PR TITLE
Accept dashboard rating fields in ConversationDocument (BAN-299)

### DIFF
--- a/hpms/database/models.py
+++ b/hpms/database/models.py
@@ -77,7 +77,7 @@ class ReviewerFlagDocument(_NonBlankRequiredFieldMixin, BaseModel):
     reviewer_by_username: str = Field(..., min_length=1)
     created_at: datetime
     categories: list[str]
-    category_other: str
+    category_other: str | None
     comment: str
 
 
@@ -150,6 +150,27 @@ class AssignedMessageDocument(_NonBlankRequiredFieldMixin, BaseModel):
     assigned_at: datetime
 
 
+class NaturalnessRatingDocument(_NonBlankRequiredFieldMixin, BaseModel):
+    """Human evaluation rating for conversational naturalness."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reviewer_id: str = Field(..., min_length=1)
+    rated_at: datetime
+    coherence: int
+    topic_progression: int
+
+
+class RealismRatingDocument(_NonBlankRequiredFieldMixin, BaseModel):
+    """Human evaluation rating for conversational realism."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reviewer_id: str = Field(..., min_length=1)
+    rated_at: datetime
+    rating: int
+
+
 class ConversationDocument(_NonBlankRequiredFieldMixin, BaseModel):
     """MongoDB conversation document matching the dashboard schema."""
 
@@ -172,6 +193,8 @@ class ConversationDocument(_NonBlankRequiredFieldMixin, BaseModel):
     opened_by: list[OpenedByDocument]
     assigned_messages: list[AssignedMessageDocument]
     reviewed_messages: list[ReviewedMessageDocument]
+    naturalness_ratings: list[NaturalnessRatingDocument] = Field(default_factory=list)
+    realism_ratings: list[RealismRatingDocument] = Field(default_factory=list)
 
     @field_validator("participant_id", mode="before")
     @classmethod

--- a/hpms/database/models.py
+++ b/hpms/database/models.py
@@ -77,7 +77,7 @@ class ReviewerFlagDocument(_NonBlankRequiredFieldMixin, BaseModel):
     reviewer_by_username: str = Field(..., min_length=1)
     created_at: datetime
     categories: list[str]
-    category_other: str | None
+    category_other: str | None = None
     comment: str
 
 

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -614,3 +614,51 @@ def test_conversation_document_requires_object_id():
 
     with pytest.raises(ValidationError, match="_id"):
         ConversationDocument.model_validate(document)
+
+
+@pytest.mark.parametrize("category_other", [None, ""])
+def test_reviewer_flag_accepts_null_and_empty_category_other(category_other):
+    now = datetime.now(timezone.utc)
+    document = _conversation_doc()
+    document["messages"] = [
+        {
+            **_message_doc(now, content="message"),
+            "reviewer_flags": [
+                {
+                    "reviewer_id": "reviewer-1",
+                    "reviewer_by_username": "alice",
+                    "created_at": now,
+                    "categories": [],
+                    "category_other": category_other,
+                    "comment": "",
+                }
+            ],
+        }
+    ]
+
+    validated = ConversationDocument.model_validate(document)
+
+    assert validated.messages[0].reviewer_flags[0].category_other == category_other
+
+
+def test_reviewer_flag_category_other_defaults_to_none_when_omitted():
+    now = datetime.now(timezone.utc)
+    document = _conversation_doc()
+    document["messages"] = [
+        {
+            **_message_doc(now, content="message"),
+            "reviewer_flags": [
+                {
+                    "reviewer_id": "reviewer-1",
+                    "reviewer_by_username": "alice",
+                    "created_at": now,
+                    "categories": [],
+                    "comment": "",
+                }
+            ],
+        }
+    ]
+
+    validated = ConversationDocument.model_validate(document)
+
+    assert validated.messages[0].reviewer_flags[0].category_other is None

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -364,6 +364,21 @@ def test_conversation_document_accepts_canonical_shape():
                     "reviewed_at": now,
                 }
             ],
+            "naturalness_ratings": [
+                {
+                    "reviewer_id": "reviewer-7",
+                    "rated_at": now,
+                    "coherence": 4,
+                    "topic_progression": 3,
+                }
+            ],
+            "realism_ratings": [
+                {
+                    "reviewer_id": "reviewer-8",
+                    "rated_at": now,
+                    "rating": 10,
+                }
+            ],
         }
     )
 
@@ -373,6 +388,8 @@ def test_conversation_document_accepts_canonical_shape():
     assert document.messages[0].duplicate_flags[0].reviewer_username == "carol"
     assert document.assigned_messages[0].reason == "participant_flag"
     assert document.reviewed_messages[0].message_index == 0
+    assert document.naturalness_ratings[0].coherence == 4
+    assert document.realism_ratings[0].rating == 10
 
 
 @pytest.mark.parametrize(
@@ -385,14 +402,6 @@ def test_conversation_document_accepts_canonical_shape():
         (
             lambda document: document.update({"assigned_to": []}),
             "assigned_to",
-        ),
-        (
-            lambda document: document.update({"naturalness_ratings": []}),
-            "naturalness_ratings",
-        ),
-        (
-            lambda document: document.update({"realism_ratings": []}),
-            "realism_ratings",
         ),
         (
             lambda document: document["messages"][0]["user_flag"].update(


### PR DESCRIPTION
## Summary
- `naturalness_ratings[]` and `realism_ratings[]` are written by the dashboard but were absent from `ConversationDocument`, causing Pydantic `extra_forbidden` errors that silently skipped every new conversation in the monitoring watcher
- Added `NaturalnessRatingDocument` and `RealismRatingDocument` models
- Added both fields to `ConversationDocument` with `default_factory=list` (older documents without them still validate)
- Removed `naturalness_ratings` and `realism_ratings` from `test_conversation_document_rejects_legacy_fields` since they are now valid fields
- Extended `test_conversation_document_accepts_canonical_shape` with rating field assertions

## Test plan
- [x] All 30 repository tests pass
- [ ] Deploy updated container and confirm no more `Skipping invalid conversation document` warnings in `hpms-monitoring-watcher-1` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)