### PR TITLE
BAN-312: Accept llm_flag assignment reason

### DIFF
--- a/hpms/database/models.py
+++ b/hpms/database/models.py
@@ -146,7 +146,9 @@ class AssignedMessageDocument(_NonBlankRequiredFieldMixin, BaseModel):
 
     reviewer_id: str = Field(..., min_length=1)
     message_index: int = Field(..., ge=0)
-    reason: Literal["random_sample", "participant_flag", "expert_escalation"]
+    reason: Literal[
+        "random_sample", "participant_flag", "expert_escalation", "llm_flag"
+    ]
     assigned_at: datetime
 
 

--- a/tests/test_database_repository.py
+++ b/tests/test_database_repository.py
@@ -524,6 +524,23 @@ def test_conversation_document_requires_top_level_message_state_lists(missing_fi
         ConversationDocument.model_validate(document)
 
 
+def test_conversation_document_accepts_llm_flag_assignment_reason():
+    now = datetime.now(timezone.utc)
+    document = _conversation_doc()
+    document["assigned_messages"] = [
+        {
+            "reviewer_id": "reviewer-1",
+            "message_index": 0,
+            "reason": "llm_flag",
+            "assigned_at": now,
+        }
+    ]
+
+    validated = ConversationDocument.model_validate(document)
+
+    assert validated.assigned_messages[0].reason == "llm_flag"
+
+
 @pytest.mark.parametrize(
     ("mutator", "match"),
     [


### PR DESCRIPTION
## Summary
- accept llm_flag as a valid assigned message reason in the conversation document schema
- add a regression test covering documents that contain the new assignment reason
- fix the validation error reported in BAN-312 when loading those documents

## Testing
- poetry run pytest tests/test_database_repository.py -q (38 passed)

## Related
- t4o BAN-312