### PR TITLE
feat: Add MSW deployment environment

### DIFF
--- a/.github/actions/resolve-service-vars/action.yml
+++ b/.github/actions/resolve-service-vars/action.yml
@@ -60,7 +60,7 @@ runs:
           dev|main|elderbot-msw-2026)
             ;;
           *)
-            echo "Unsupported branch: ${branch}. Expected dev or main." >&2
+            echo "Unsupported branch: ${branch}. Expected dev, main, or elderbot-msw-2026." >&2
             exit 1
             ;;
         esac

--- a/.github/actions/resolve-service-vars/action.yml
+++ b/.github/actions/resolve-service-vars/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: Registry namespace/prefix
     required: true
   branch:
-    description: Git branch name (dev or main)
+    description: Git branch name (dev, main, or elderbot-msw-2026)
     required: true
   sha:
     description: Git commit SHA
@@ -57,7 +57,7 @@ runs:
         esac
 
         case "$branch" in
-          dev|main)
+          dev|main|elderbot-msw-2026)
             ;;
           *)
             echo "Unsupported branch: ${branch}. Expected dev or main." >&2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,7 +2,7 @@ name: Deployment
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev, main, elderbot-msw-2026]
   workflow_dispatch:
 
 permissions:
@@ -142,8 +142,10 @@ jobs:
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
           MONGODB_URI_DEV: ${{ secrets.MONGODB_URI_DEV }}
           MONGODB_URI_MAIN: ${{ secrets.MONGODB_URI_MAIN }}
+          MONGODB_URI_MSW: ${{ secrets.MONGODB_URI_MSW }}
           MONGODB_DATABASE_DEV: ${{ vars.MONGODB_DATABASE_DEV }}
           MONGODB_DATABASE_MAIN: ${{ vars.MONGODB_DATABASE_MAIN }}
+          MONGODB_DATABASE_MSW: ${{ vars.MONGODB_DATABASE_MSW }}
           OPENAI_MODERATION_API_KEY: ${{ secrets.OPENAI_MODERATION_API_KEY }}
           LLAMA_GUARD_API_KEY: ${{ secrets.LLAMA_GUARD_API_KEY }}
           LLAMA_GUARD_ENDPOINT: ${{ vars.LLAMA_GUARD_ENDPOINT }}
@@ -168,6 +170,10 @@ jobs:
             main)
               mongodb_uri="$MONGODB_URI_MAIN"
               mongodb_database="$MONGODB_DATABASE_MAIN"
+              ;;
+            elderbot-msw-2026)
+              mongodb_uri="$MONGODB_URI_MSW"
+              mongodb_database="$MONGODB_DATABASE_MSW"
               ;;
             *)
               echo "Unsupported branch: ${branch}" >&2

--- a/docs/ci-cd-deployment.md
+++ b/docs/ci-cd-deployment.md
@@ -18,6 +18,7 @@ Supported deployment branches:
 
 - `dev`
 - `main`
+- `elderbot-msw-2026`
 
 Workflow triggers:
 
@@ -34,6 +35,7 @@ Workflow triggers:
 - GitHub Actions deployment environment:
   - `dev` branch deploys to the `dev` GitHub environment
   - `main` branch deploys to the `main` GitHub environment
+  - `elderbot-msw-2026` branch deploys to the `elderbot-msw-2026` GitHub environment
 
 ## Build and Deploy Logic
 
@@ -92,6 +94,7 @@ Optional values with defaults:
 | `CHAT_COMPLETIONS_MODEL_NAME` | Chat model name used by watcher conversation processing               |
 | `MONGODB_DATABASE_DEV`        | MongoDB database name for `dev` deployments                           |
 | `MONGODB_DATABASE_MAIN`       | MongoDB database name for `main` deployments                          |
+| `MONGODB_DATABASE_MSW`        | MongoDB database name for `elderbot-msw-2026` deployments             |
 
 Optional variables:
 
@@ -111,6 +114,7 @@ Optional variables:
 | `DOCKERCFG`                 | Base64 Docker config JSON for Kubernetes image pull secret |
 | `MONGODB_URI_DEV`           | Watcher MongoDB URI for `dev` deployments                  |
 | `MONGODB_URI_MAIN`          | Watcher MongoDB URI for `main` deployments                 |
+| `MONGODB_URI_MSW`           | Watcher MongoDB URI for `elderbot-msw-2026` deployments    |
 | `MODEL_API_KEY`             | Provider API key used by watcher conversation processing   |
 | `LANGFUSE_PUBLIC_KEY`       | Langfuse public API key used by watcher telemetry          |
 | `LANGFUSE_SECRET_KEY`       | Langfuse secret API key used by watcher telemetry          |


### PR DESCRIPTION
## Summary

- Adds `elderbot-msw-2026` to the deployment workflow branch trigger
- Routes the branch to new `MONGODB_URI_MSW` / `MONGODB_DATABASE_MSW` credentials in the watcher deployment step
- Documents the new environment, secret, and variable in `docs/ci-cd-deployment.md`

## Pre-requisites (must be done in GitHub Settings before deploying)

- [x] Create GitHub Actions **environment** named `elderbot-msw-2026` (Settings → Environments)
- [x] Add **secret** `MONGODB_URI_MSW` — MongoDB connection URI for MSW
- [x] Add **variable** `MONGODB_DATABASE_MSW` — MongoDB database name for MSW
- [x] Create branch `elderbot-msw-2026` off `dev`

## Test plan

- [x] Merge this PR into `dev`
- [x] Complete the pre-requisites above
- [x] Push to `elderbot-msw-2026` and verify the Deployment workflow runs without the "Unsupported branch" error
- [ ] Confirm the watcher pod is deployed in the `elderbot-msw-2026` GitHub environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)