### PR TITLE
fix: Rename HPMS deployment to hpms-watcher prefix (BAN-148)

### DIFF
--- a/.github/actions/resolve-service-vars/action.yml
+++ b/.github/actions/resolve-service-vars/action.yml
@@ -65,7 +65,9 @@ runs:
             ;;
         esac
 
-        app_name="${{ inputs.app-name-prefix }}-${service}-${branch}"
+        # Compose a stable Helm release + image name.
+        # Desired format: hpms-<service>-<APP_NAME>-<branch>
+        app_name="hpms-${service}-${{ inputs.app-name-prefix }}-${branch}"
         image_name="${app_name}"
         image_tag="${sha::7}"
         full_image="${{ inputs.registry }}/${{ inputs.docker-registry-prefix }}/${image_name}:${image_tag}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/resolve-service-vars
         with:
           service: ${{ matrix.service }}
-          app-name-prefix: ${{ vars.APP_NAME }}
+          app-name-prefix: ${{ github.ref_name == 'elderbot-msw-2026' && vars.APP_NAME_MSW || vars.APP_NAME }}
           registry: ${{ env.REGISTRY }}
           docker-registry-prefix: ${{ env.DOCKER_REGISTRY_PREFIX }}
           branch: ${{ github.ref_name }}
@@ -122,7 +122,7 @@ jobs:
         uses: ./.github/actions/resolve-service-vars
         with:
           service: ${{ matrix.service }}
-          app-name-prefix: ${{ vars.APP_NAME }}
+          app-name-prefix: ${{ github.ref_name == 'elderbot-msw-2026' && vars.APP_NAME_MSW || vars.APP_NAME }}
           registry: ${{ env.REGISTRY }}
           docker-registry-prefix: ${{ env.DOCKER_REGISTRY_PREFIX }}
           branch: ${{ github.ref_name }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Validate MSW app name variable
+        if: github.ref_name == 'elderbot-msw-2026'
+        shell: bash
+        run: |
+          [[ -n "${{ vars.APP_NAME_MSW }}" ]] || {
+            echo "APP_NAME_MSW variable is not set for MSW branch deployment" >&2
+            exit 1
+          }
+
       - name: Resolve service variables
         id: vars
         uses: ./.github/actions/resolve-service-vars
@@ -116,6 +125,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Validate MSW app name variable
+        if: github.ref_name == 'elderbot-msw-2026'
+        shell: bash
+        run: |
+          [[ -n "${{ vars.APP_NAME_MSW }}" ]] || {
+            echo "APP_NAME_MSW variable is not set for MSW branch deployment" >&2
+            exit 1
+          }
 
       - name: Resolve service variables
         id: vars

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/batch
 notebooks/*.html
 notebooks/*.out.ipynb
 *.png
+.claude/worktrees
 
 # Pytest
 .test_report.xml

--- a/docs/ci-cd-deployment.md
+++ b/docs/ci-cd-deployment.md
@@ -41,7 +41,7 @@ Workflow triggers:
 
 The `watcher` service follows this flow:
 
-1. Resolve deterministic app/image naming (`<APP_NAME>-watcher-<branch>`).
+1. Resolve deterministic app/image naming (`hpms-watcher-<APP_NAME>-<branch>`).
 1. Build and push Docker image from `Dockerfile`.
 1. Generate `/tmp/deployment_vars.yml` for runtime environment values.
 1. Deploy with local `deploy-helm` composite action only when the build job succeeds.
@@ -86,7 +86,8 @@ Optional values with defaults:
 | Variable                      | Purpose                                                               |
 | ----------------------------- | --------------------------------------------------------------------- |
 | `GITLAB_REGISTRY`             | Docker registry host                                                  |
-| `APP_NAME`                    | Application name prefix used in image/release naming                  |
+| `APP_NAME`                    | Application slug used in image/release naming (no `hpms-` prefix)     |
+| `APP_NAME_MSW`                | Application slug for MSW environment (elderbot-msw-2026 branch)       |
 | `LLAMA_GUARD_ENDPOINT`        | Llama Guard endpoint URL                                              |
 | `LANGFUSE_HOST`               | Langfuse base URL used for telemetry export                           |
 | `MODEL_ENDPOINT`              | Chat/completions provider endpoint used by watcher                    |
@@ -120,6 +121,10 @@ Optional variables:
 | `LANGFUSE_SECRET_KEY`       | Langfuse secret API key used by watcher telemetry          |
 | `OPENAI_MODERATION_API_KEY` | OpenAI moderation key used by watcher                      |
 | `LLAMA_GUARD_API_KEY`       | Llama Guard API key used by watcher                        |
+
+## Rename / migration note (Helm release name)
+
+The resolved app name is used as the **Helm release name**. If you change the naming scheme (or change `APP_NAME`), Helm will treat it as a different release and will **create a new release** on the next deployment, leaving the old release behind until you remove it.
 
 ## Kubernetes Chart Contract
 


### PR DESCRIPTION
## Summary

- Fixes BAN-148: Rename HPMS deployment to use hpms-watcher prefix
- Updates deployment workflow to use `vars.APP_NAME_MSW` when branch is `elderbot-msw-2026`
- Adds support for distinct application naming in MSW environment
- Updates documentation to reflect the new naming convention: `hpms-watcher-<APP_NAME>-<branch>`

## Changes

- Modified `.github/workflows/deployment.yml` to conditionally use `vars.APP_NAME_MSW` for elderbot-msw-2026 branch
- Updated `docs/ci-cd-deployment.md` to document the new naming convention and migration notes
- Added `APP_NAME_MSW` to the required GitHub variables documentation

## Test plan

- [ ] Verify MSW deployment uses correct naming with `vars.APP_NAME_MSW`
- [ ] Confirm other branches continue using `vars.APP_NAME`
- [ ] Check Helm release naming matches expected pattern

🤖 Generated with [Claude Code](https://claude.ai/code)